### PR TITLE
Reorganize existing codebase

### DIFF
--- a/ci_action/__init__.py
+++ b/ci_action/__init__.py
@@ -1,0 +1,2 @@
+from .main import main
+from . import implementation

--- a/ci_action/implementation.py
+++ b/ci_action/implementation.py
@@ -1,0 +1,309 @@
+"""Webhook implementation for Github"""
+
+import os
+import json
+import urllib.parse
+import base64
+import concurrent.futures
+import hmac
+import hashlib
+import email
+import gzip
+import boto3
+import botocore
+import botocore.session
+import random
+import time
+import traceback
+import tempfile
+import uuid
+import zipfile
+
+from library import aws_client
+from library import pr_resolve
+from library import github_client
+
+client = botocore.session.get_session().create_client('secretsmanager')
+s3 = boto3.client('s3')
+
+# This is a constructor for the configuration needed to submit AWS Batch jobs.
+# This constructor reads configuration from the environment and must be
+# configured via environmental variables set in the Lambda function. Note that
+# the timeout is set to is 4 hours since even a full cache rebuild should much
+# less time. For information on the config variables.
+BATCH_SUBMIT_ENV = aws_client.BatchSubmitConfigFromEnv(timeout=60*240)
+
+github_webhook_secret_arn = os.environ.get('GITHUB_WEBHOOK_SECRET_ARN')
+
+ACTIONABLE_ACTIONS = ['pull_request:opened', 'pull_request:synchronize']
+IGNORE_ACTIONS = ['check_run:completed', 'check_run:created']
+
+BUILD_ENVIRONMENTS = ['gcc', 'intel', 'gcc11']
+
+
+class TimeCheckpointer:
+    def __init__(self):
+        self._checkpoint_time = time.time()
+
+    def checkpoint(self):
+        """Get elapsed time in seconds."""
+        time_now = time.time()
+        checkpoint_delta = round(time_now - self._checkpoint_time, 4)
+        self._checkpoint_time = time_now
+        return f'<time elapsed: {checkpoint_delta} seconds>'
+
+
+def lambda_handler(event, _context):
+    """Webhook function"""
+    headers = event.get('headers')
+
+    # Input validation; this lambda function handles a GitHub webhook event
+    # and expects a standard event json payload.
+    try:
+        json_payload = get_json_payload(event=event)
+    except ValueError as err:
+        traceback.print_exception(type(err), value=err, tb=err.__traceback__)
+        print_error(f'400 Bad Request - {err}', headers)
+        return {'statusCode': 400, 'body': str(err)}
+    except Exception as err:  # Unexpected Error
+        traceback.print_exception(type(err), value=err, tb=err.__traceback__)
+        print_error('500 Internal Server Error\n' +
+                    f'Unexpected error: {err}, {type(err)}', headers)
+        return {'statusCode': 500, 'body': 'Internal Server Error'}
+    # Validate webhook signature.
+    if not contains_valid_signature(event=event):
+        traceback.print_exception(type(err), value=err, tb=err.__traceback__)
+        print_error('401 Unauthorized - Invalid Signature', headers)
+        return {'statusCode': 401, 'body': 'Invalid Signature'}
+
+    # Process event.
+    detail_type = headers.get('x-github-event', 'github-webhook-lambda')
+    try:
+        process_event(json_payload, detail_type)
+        return {'statusCode': 202, 'body': 'Webhook processed'}
+    except Exception as err:  # Unexpected Error
+        traceback.print_exception(type(err), value=err, tb=err.__traceback__)
+        print_error('500 Internal Server Error\n' +
+                    f'Unexpected error: {err}, {type(err)}', headers)
+        return {'statusCode': 500, 'body': 'Internal Server Error'}
+
+
+def contains_valid_signature(event):
+    """Check for the payload signature
+       Github documention: https://docs.github.com/en/developers/webhooks-and-events/webhooks/securing-your-webhooks#validating-payloads-from-github
+    """
+    secret = aws_client.get_secret_string(github_webhook_secret_arn)
+    payload_bytes = get_payload_bytes(
+        raw_payload=event['body'], is_base64_encoded=event['isBase64Encoded'])
+    computed_signature = compute_signature(
+        payload_bytes=payload_bytes, secret=secret)
+
+    return hmac.compare_digest(event['headers'].get('x-hub-signature-256', ''), computed_signature)
+
+
+def get_payload_bytes(raw_payload, is_base64_encoded):
+    """Get payload bytes to feed hash function"""
+    if is_base64_encoded:
+        return base64.b64decode(raw_payload)
+    else:
+        return raw_payload.encode()
+
+
+def compute_signature(payload_bytes, secret):
+    """Compute HMAC-SHA256"""
+    m = hmac.new(key=secret.encode(), msg=payload_bytes,
+                 digestmod=hashlib.sha256)
+    return 'sha256=' + m.hexdigest()
+
+
+def get_json_payload(event):
+    """Get JSON string from payload"""
+    content_type = get_content_type(event.get('headers', {}))
+    if not (content_type == 'application/json' or
+            content_type == 'application/x-www-form-urlencoded'):
+        raise ValueError(f'Unsupported content-type: {content_type}')
+
+    raw_payload = event.get('body')
+    if raw_payload is None:
+        raise ValueError('Missing event body')
+    payload = raw_payload
+    if event['isBase64Encoded']:
+        payload = base64.b64decode(raw_payload).decode('utf-8')
+
+    if content_type == 'application/x-www-form-urlencoded':
+        parsed_qs = urllib.parse.parse_qs(payload)
+        if 'payload' not in parsed_qs or len(parsed_qs['payload']) != 1:
+            raise ValueError('Invalid urlencoded payload')
+        payload = parsed_qs['payload'][0]
+
+    try:
+       payload = json.loads(payload)
+    except ValueError as err:
+        raise ValueError('Invalid JSON payload') from err
+
+    return payload
+
+
+def upload_to_aws(json_data, s3_file):
+    """Upload file to S3 bucket"""
+    if isinstance(json_data, str):
+        json_data = json_data.encode('utf-8')
+    bucket = os.environ['BUCKET_NAME']
+    s3.put_object(Body=json_data, Bucket=bucket, Key=s3_file)
+    s3_path = f's3://{bucket}/{s3_file}'
+    return s3_path
+
+
+def process_event(payload, detail_type):
+    """Create file for S3 bucket"""
+    timer = TimeCheckpointer()
+    trigger_repo = payload['repository']['full_name']
+    trigger_repo_uri = payload['repository']['clone_url']
+    owner, repo_name = trigger_repo.split('/')
+    action = payload.get('action', '')
+    detail_action = f'{detail_type}:{action}'
+    print(f'Event: {detail_type}. Action: {action}. Repo: {trigger_repo}')
+
+    # vars that must be pulled from the event.
+    branch_name = ''
+    pull_request_number = -1
+    pr_payload = None
+
+    if detail_action in ACTIONABLE_ACTIONS and detail_type == 'pull_request':
+        branch_name = payload['pull_request']['head']['ref']
+        pull_request_number = payload['pull_request']['number']
+        pr_payload = payload['pull_request']
+        trigger_commit = payload['pull_request']['head']['sha']
+    elif detail_action in IGNORE_ACTIONS:  # Known events with no action.
+        print(f'Ignoring {trigger_repo}: event "{detail_type}:{action}"')
+        return
+    else:  # These are unknown events.
+        print(f'No processor for event "{detail_type}" with action "{action}"')
+        print(f'{payload}')
+        return
+
+    if pull_request_number <= 0:
+        print(f'{detail_type} event on {branch_name} found no associated PR')
+        print(f'{payload}')
+        return
+
+    print(f'Evaluated Git event. {timer.checkpoint()}')
+    build_info_payload, run_tests, test_select, build_env_suffix = pr_resolve.get_prs(
+        trigger_repo=repo_name,
+        trigger_uri=trigger_repo_uri,
+        trigger_pr_id=pull_request_number,
+        trigger_commit=trigger_commit,
+        pr_payload=pr_payload)
+    if not run_tests:
+        print(f'Skipping tests for "{repo_name}#{pull_request_number}"')
+        return
+    test_script = build_info_payload['test_script']
+    short_commit = trigger_commit[0:7]
+    debug_time = build_info_payload['debug_time']
+    print(f'Got PR payload. {timer.checkpoint()}')
+
+    # Map of futures to environment names. Note that future objects are hashable
+    # even before they return, so they can be used as dict keys.
+    check_run_future_to_env = {}
+
+    # Create the check "unit" and "integration" payloads using a thread pool;
+    # The GitHub API is a bit slow and we can take advantage of this by creating
+    # all the check runs in a thread pool allowing each thread to wait on the
+    # requests independently. Each future returns a dictionary with the Check
+    # Run ID mapped to the run type, ex {'unit': -id-, 'integration': -id'}.
+    with concurrent.futures.ThreadPoolExecutor(max_workers=5) as executor:
+
+        if test_select == 'random':
+            chosen_build_environments = [random.choice(BUILD_ENVIRONMENTS)]
+        elif test_select == 'all':
+            chosen_build_environments = [e for e in BUILD_ENVIRONMENTS]
+        else:
+            chosen_build_environments = [test_select]
+
+        # Submit check-run create requests via the thread pool (see above).
+        for build_environment in chosen_build_environments:
+            check_run_future = executor.submit(
+                github_client.create_check_runs,
+                build_environment,
+                repo_name,
+                owner,
+                trigger_commit,
+                build_env_suffix)
+            check_run_future_to_env[check_run_future] = build_environment
+
+        # Watch the thread pool futures and create the build jobs when done.
+        for future in concurrent.futures.as_completed(check_run_future_to_env):
+            build_environment = check_run_future_to_env[future]
+            try:
+                check_run_id_map = future.result()
+            except Exception as exc:
+                print(f'Failed to create check runs for {build_environment}'
+                      f'due to exception: {exc}')
+                continue
+
+            # Attach check-run IDs to the PR payload allowing the test runner to
+            # update each check run with a link to the job logs.
+            build_info_payload['check_runs'] = check_run_id_map
+            print(f'Created check runs. {timer.checkpoint()}')
+
+            # The build info message is converted to json, compressed, then
+            # encoded as base64 so that it can be passed to the build container.
+            # This compression is necessary because there is a limit of 8192
+            # characters in the 'overrides' message used by the underlying
+            # ECS run task API.
+            # https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html
+            build_info_zipped = gzip.compress(json.dumps(build_info_payload).encode('utf8'))
+            build_info_b64 = base64.b64encode(build_info_zipped).decode()
+
+            # Create the AWS Batch job that will execute both the unit and the
+            # integration test. The batch job executes a job definition stored
+            # in AWS (see cfn/batch-backend.yaml for our job definitions). The
+            # job takes the build info json file as an argument and this file
+            # configures the build.
+            job = aws_client.submit_test_batch_job(
+                config=BATCH_SUBMIT_ENV.get_config(build_environment + build_env_suffix),
+                repo_name=repo_name,
+                commit=short_commit,
+                pr=pull_request_number,
+                test_script=test_script,
+                build_identity=f'{repo_name}-{pull_request_number}-{short_commit}-{build_environment}',
+                debug_time=debug_time,
+                build_info=build_info_b64,
+            )
+            job_arn = job['jobArn']
+            print(f'Submitted Batch Job: "{job_arn}". {timer.checkpoint()}')
+
+
+def get_content_type(headers):
+    """Helper function to parse content-type from the header"""
+    raw_content_type = headers.get('content-type')
+
+    if raw_content_type is None:
+        return None
+    # This is Python's recommended std. lib. method for decoding content type.
+    msg = email.message.EmailMessage()
+    msg['content-type'] = raw_content_type
+    return msg.get_content_type()
+
+
+def print_error(message, headers):
+    """Helper function to print errors"""
+    print(f'ERROR: {message}\nHeaders: {str(headers)}')
+
+
+if __name__ == '__main__':
+    if os.environ.get('LAMBDA_TEST_GET_PRS'):
+        print(pr_resolve.get_prs('oops', 2179))
+    elif os.environ.get('TEST_GITHUB_EVENT_JSON'):
+        event_json_file = os.environ.get('TEST_GITHUB_EVENT_JSON')
+        with open(event_json_file, 'r') as f:
+            raw_struct = f.read()
+        event = {
+            'isBase64Encoded': False,
+            'body': raw_struct,
+            'headers': {
+                'x-github-event': 'pull_request',
+                'content-type': 'application/json',
+            },
+        }
+        lambda_handler(event, None)

--- a/ci_action/library/aws_client.py
+++ b/ci_action/library/aws_client.py
@@ -1,0 +1,164 @@
+"""Wrappers for AWS functions where direct API access isn't desired.
+
+"""
+
+import boto3
+import os
+import time
+import functools
+
+SECRET_CLIENT = boto3.session.Session().client(service_name='secretsmanager')
+BATCH_CLIENT = boto3.session.Session().client(service_name='batch')
+
+def ttl_lru_cache(ttl, maxsize=100):
+    """Least-recently-used (LRU) cache function decorator with time-to-live
+    (TTL) windowing.
+
+    This cache is not the most advanced implementation of the idea but it
+    is (relatively) simple. The TTL is enforced via time windowing by feeding
+    the time window to the builtin LRU cache as a parameter. While cached
+    objects may expire sooner than strictly necessary, the cache will never
+    return objects that have outlived their TTL.
+
+    Args:
+      ttl: the number of seconds for cache item TTL.
+      maxsize: the maximum number of items allowed in the cache before
+               new items evict the least recently used items.
+    """
+
+    def decorator(f):
+        # Define the cached function that will be called.
+        @functools.lru_cache(maxsize)
+        def ttl_keyed_function(*args, ttl_hash, **kwargs):
+            del ttl_hash  # The hash is only used to key the lru_cache.
+            return f(*args, **kwargs)
+
+        # The wrapped function with the original signature will generate the
+        # TTL hash and call the TTL keyed function. This function will be
+        # returned by the decorator.
+        @functools.wraps(f)
+        def wrapped_func_hidden_ttl_key(*args, **kwargs):
+            return ttl_keyed_function(
+                *args, ttl_hash=int(time.time()/ttl), **kwargs)
+
+        return wrapped_func_hidden_ttl_key
+    return decorator
+
+
+@ttl_lru_cache(ttl=3600)  # Secrets expire after an hour.
+def get_secret_string(secret_arn):
+    """Get a secret value from aws secret store."""
+    get_secret_value_response = SECRET_CLIENT.get_secret_value(
+        SecretId=secret_arn
+    )
+    # Secrets Manager decrypts the secret value using the associated KMS CMK
+    # Depending on whether the secret was a string or binary, only one of these
+    # fields will be populated
+    if 'SecretString' in get_secret_value_response:
+        return get_secret_value_response['SecretString']
+    else:
+        return get_secret_value_response['SecretBinary']
+
+
+class BatchSubmitConfig(object):
+    """A batch job config used to submit an AWS batch job."""
+
+    def __init__(self, job_definition, job_queue, timeout, build_environment):
+        self.job_definition = job_definition
+        self.job_queue = job_queue
+        self.timeout = timeout
+        self.build_environment = build_environment
+
+
+class BatchSubmitConfigFromEnv(object):
+    """Collect batch job config values from the environment.
+
+    This class is configured using the following environment variables. If any
+    are unset, the class cannot be instantiated.
+
+    Environment configuration:
+        BATCH_JOB_DEFINITION_CLANG: the ARN of the "clang" test batch job def.
+        BATCH_JOB_DEFINITION_GNU: the ARN of the "gcc" test batch job def.
+        BATCH_JOB_DEFINITION_INTEL: the ARN of the "intel" test batch job def.
+        BATCH_JOB_QUEUE: the ARN of the Batch job queue used for testing jobs.
+    """
+
+    def __init__(self, timeout):
+        """Init from environment."""
+        self._job_def_map = {
+            'gcc11': os.environ.get('BATCH_JOB_DEFINITION_CLANG', ''),
+            'gcc': os.environ.get('BATCH_JOB_DEFINITION_GNU', ''),
+            'intel': os.environ.get('BATCH_JOB_DEFINITION_INTEL', ''),
+            'gcc11-next': os.environ.get('BATCH_JOB_DEFINITION_CLANG_NEXT', ''),
+            'gcc-next': os.environ.get('BATCH_JOB_DEFINITION_GNU_NEXT', ''),
+            'intel-next': os.environ.get('BATCH_JOB_DEFINITION_INTEL_NEXT', ''),
+        }
+        self._job_queue = os.environ.get('BATCH_JOB_QUEUE', '')
+        self._timeout = timeout
+        # Validate job definition ARNs.
+        for job_name, job_arn in self._job_def_map.items():
+            if not job_arn.startswith('arn:aws:batch'):
+                raise EnvironmentError(
+                    f'Variable BATCH_JOB_DEFINITION_* for "{job_name}"'
+                    f'is not a AWS Batch service arn. Found "{job_arn}"')
+        if not self._job_queue.startswith('arn:aws:batch'):
+            raise EnvironmentError(
+                f'BATCH_JOB_QUEUE "{self._job_queue}" is not an AWS Batch '
+                'service arn. Value must start with "arn:aws:batch"')
+
+    def get_config(self, build_environment):
+        """Get a BatchSubmitConfig for a named environment."""
+        if build_environment not in self._job_def_map:
+            raise ValueError(f'no job definition for "{build_environment}"; '
+                             f'in job definition map: {self._job_def_map}')
+        return BatchSubmitConfig(
+            job_definition=self._job_def_map[build_environment],
+            job_queue=self._job_queue,
+            timeout=self._timeout,
+            build_environment=build_environment)
+
+
+def submit_test_batch_job(
+        config: BatchSubmitConfig,
+        repo_name: str,
+        commit: str,
+        pr: int,
+        test_script: str,
+        build_identity: str,
+        debug_time: int,
+        build_info: str,
+    ):
+    """Submit a CI batch job."""
+    job_name = f'jedi-ci-{repo_name}-{pr}-{commit}-{config.build_environment}'
+    return BATCH_CLIENT.submit_job(
+        jobName=job_name,
+        jobQueue=config.job_queue,
+        jobDefinition=config.job_definition,
+        timeout={
+            'attemptDurationSeconds': config.timeout,
+        },
+        containerOverrides={
+            'environment': [
+                {
+                    'name': 'TRIGGER_REPO',
+                    'value': repo_name,
+                },
+                {
+                    'name': 'BUILD_IDENTITY',
+                    'value': build_identity
+                },
+                {
+                    'name': 'DEBUG_TIME_SECONDS',
+                    'value': f'{debug_time}',
+                },
+                {
+                    'name': 'BUILD_INFO_B64',
+                    'value': build_info,
+                },
+                {
+                    'name': 'TEST_SCRIPT',
+                    'value': test_script,
+                }
+            ],
+        },
+    )

--- a/ci_action/library/github_client.py
+++ b/ci_action/library/github_client.py
@@ -1,0 +1,177 @@
+"""GitHub client wrapper for Lambda function.
+
+Our GitHub Lambda function will use a GitHub app integration for accessing
+repository metadata and code. GitHub app integration credentials work with
+credentials scoped to the "install" which is associated with a user or an
+organization; a single application may have many installs.
+
+This library provides the class GitHubAppClientManager whose instances will
+evaluate an application and eagerly create the full set  of the GitHub clients.
+Using this manager the caller may access the client directly, or make the
+'get_repository' call which will automatically use the correct client and
+return a github.Repository object.
+
+The GitHubAppClientManager may be initialized directly, or may be initialized
+using the following environment variables:
+  - GITHUB_APP_ID: GitHub App ID, usually a set of numbers (eg. "12345").
+  - GITHUB_APP_KEY_ARN: The AWS ARN identifier for the GitHub app private
+                        RSA key.
+
+This utility can also fall back to using a personal access token (PAT) which is
+helpful for local development. Set GITHUB_TOKEN_FILE to the location of a file
+containing a personal access token. The application credentials will not be used
+when a PAT is provided.
+"""
+import datetime
+import github
+import jwt
+import logging
+import os
+import random
+import time
+
+from library import aws_client
+
+
+# The init_from_environment() acts as a singleton instantiator to reduce
+# duplication of API calls. Once that method is called, the client manager
+# object will be kept here.
+_GITHUB_ENVIRONMENT_CLIENT = None
+
+
+class GitHubAppClientManager(object):
+    """A wrapper for the GitHub client that efficiently uses app credentials.
+
+    Figuring out which app credential should be used to fetch a repository
+    requires using the App's JSON Web Token (JWT) credentials to query the
+    target repository for installations, or it requires using credentials to
+    pre-fetch all installations. This utility takes the latter approach and
+    pre-create the correctly authenticated GitHub client for each target
+    install.
+
+    This manager relies on the undocumented (but public) API feature in
+    pygithub allowing the use of an AppAuthentication struct to create a Github
+    client with refreshable JWT credentials. The client for each install can be
+    reused indefinitely since credential expiration is tracked and refreshed
+    by the client interface.
+
+    In addition to supporting application authentication, this manager supports
+    personal access tokens so that it can be used during local development. If
+    a personal access token is used then app credentials cannot be used.
+    """
+
+    def __init__(self,
+                 app_id: str,
+                 app_private_key: str,
+                 personal_access_token: str = ""):
+        """Initialize the GitHubAppClientManager."""
+        self._app_clients = {}
+        self._integration = None
+        if (app_id or app_private_key) and personal_access_token:
+            raise ValueError(
+                "You must initialize with app credentials or personal access "
+                "token credentials, the use of both is not allowed.")
+        # Personal access token case short circuits much of this object's use
+        # but should be supported to allow development elsewhere.
+        if personal_access_token:
+            self._pat_client = github.Github(personal_access_token)
+            return
+        # Support for app credentials.
+        self._pat_client = None
+        self._integration = github.GithubIntegration(
+            app_id,
+            app_private_key,
+            jwt_expiry=599)
+
+        for installation in self._integration.get_installations():
+            auth = github.AppAuthentication(
+                    app_id=app_id,
+                    private_key=app_private_key,
+                    installation_id=installation.id)
+            client = github.Github(app_auth=auth)
+            client_name = installation.raw_data['account']['login'].lower()
+            self._app_clients[client_name] = client
+
+    @classmethod
+    def init_from_environment(cls):
+        global _GITHUB_ENVIRONMENT_CLIENT
+        if _GITHUB_ENVIRONMENT_CLIENT:
+            return _GITHUB_ENVIRONMENT_CLIENT
+
+        if 'GITHUB_TOKEN_FILE' in os.environ:
+            with open(os.environ['GITHUB_TOKEN_FILE'], 'r') as f:
+                _GITHUB_ENVIRONMENT_CLIENT = cls(
+                    None, None, personal_access_token=f.read().strip())
+                return _GITHUB_ENVIRONMENT_CLIENT
+        if 'GITHUB_APP_ID' in os.environ and 'GITHUB_APP_KEY_ARN' in os.environ:
+            app_key = aws_client.get_secret_string(
+                os.environ['GITHUB_APP_KEY_ARN'])
+            app_id = os.environ['GITHUB_APP_ID']
+            _GITHUB_ENVIRONMENT_CLIENT = cls(app_id, app_key, None)
+            return _GITHUB_ENVIRONMENT_CLIENT
+        raise EnvironmentError(
+            'Environment must have var "GITHUB_TOKEN_FILE" or vars'
+            '"GITHUB_APP_ID" and "GITHUB_APP_KEY_ARN".')
+
+    def get_client(self, owner):
+        """Select the correct GitHub client for a repository.
+
+        Private repositories need the client associated with the app
+        integration. Public repositories can use any client. This routine looks
+        for an app integration and if it fails a random client is returned. Note
+        that if we add private repositories without an integration, then we
+        will get authorization errors.
+        """
+        owner = owner.lower()
+        if owner in self._app_clients:
+            return self._app_clients.get(owner.lower())
+        return random.choice(list(self._app_clients.values()))
+
+    def get_active_prs(self, repo, owner):
+        print(f'Fetching pull requests for {owner}/{repo}')
+        repo = self.get_repository(repo, owner)
+        return repo.get_pulls(state='open')
+
+    def get_repository(self, repo, owner):
+        client = self.get_client(owner)
+        return client.get_repo(f'{owner}/{repo}')
+
+    def create_check_run(self, repo, owner, commit, run_name):
+        """Create a new GitHub check run."""
+        repo = self.get_repository(repo, owner)
+        check_run = repo.create_check_run(
+            run_name,
+            commit,
+            status='queued',
+        )
+        return check_run
+
+
+def create_check_runs(build_environment, repo, owner, trigger_commit, next_suffix):
+    """Create check runs (unit and integration) for a given build environment.
+
+    Args:
+        build_environment: intel, gcc, or gcc11 (or any other supported build
+            environment).
+        repo: The name of the repository.
+        owner: The owner of the repository (probably "jcsda-internal").
+        trigger_commit: the commit associated with the check run.
+        next_suffix: an empty string or "-next" used to indicate use of the
+                     pre-release test images in the job name.
+
+    Returns:
+        Struct of check run ID's.
+        {
+            "integration": 14645415163,
+            "unit": 14645415264,
+        }
+    """
+    build_environment_name = build_environment + next_suffix
+    github_app = GitHubAppClientManager.init_from_environment()
+    unit_run_name = f'JEDI unit test: {build_environment_name}'
+    integration_run_name = f'JEDI integration test: {build_environment_name}'
+    unit_run = github_app.create_check_run(
+        repo, owner, trigger_commit, unit_run_name)
+    integration_run = github_app.create_check_run(
+        repo, owner, trigger_commit, integration_run_name)
+    return {'unit': unit_run.id, 'integration': integration_run.id}

--- a/ci_action/library/pr_resolve.py
+++ b/ci_action/library/pr_resolve.py
@@ -1,0 +1,402 @@
+import json
+import logging
+import os
+import re
+from typing import Any, Mapping, NamedTuple, Tuple, Union
+
+import github
+
+from library import github_client
+from library import aws_client
+
+
+logging.basicConfig(level=logging.INFO)
+GITHUB_URI = "https://github.com/"
+
+GITHUB_CLIENT = github_client.GitHubAppClientManager.init_from_environment()
+
+INTEGRATED_ORG_WHITELIST = frozenset(['jcsda-internal', 'jcsda', 'geos-esm'])
+
+# Build group regex searches for instances of "build-group=<PR link>". The link
+# may be a literal GitHub URL, or it can be a short-link that is also respected
+# by the GitHub UI. Because the link format isn't known initially, we match
+# against any possible set of URL characters and refine the match in a later
+# step.
+BUILD_GROUP_RE = re.compile(
+    r'^build-group\s?=\s?([a-zA-Z0-9\/:#\._-]{10,70})\s*$', re.MULTILINE | re.IGNORECASE)
+# Once the build group line is captured, this is used to parse the repository
+# and pull request number from the captured text.
+BUILD_GROUP_LINK = re.compile(
+    r'([A-Za-z0-9._-]{3,30})/([A-Za-z0-9._-]{3,40})(?:#|/pull/)([0-9]{1,7})\s*$')
+CACHE_BEHAVIOR_RE = re.compile(
+    r'^jedi-ci-build-cache\s?=\s?(skip|rebuild)\s*$', re.MULTILINE | re.IGNORECASE)
+DRAFT_PR_RUN_RE = re.compile(
+    r'^run-ci-on-draft\s?=\s?([a-zA-Z]{0,10})\s*$', re.MULTILINE | re.IGNORECASE)
+DEBUG_CI_RE = re.compile(
+    r'^jedi-ci-debug\s?=\s?t(rue)?\s*$', re.MULTILINE | re.IGNORECASE)
+NEXT_CI_RE = re.compile(
+    r'^jedi-ci-next\s?=\s?t(rue)?\s*$', re.MULTILINE | re.IGNORECASE)
+CI_TEST_SELECT_RE = re.compile(
+    r'^jedi-ci-test-select\s?=\s?(random|all|intel|gcc|gcc11)?\s*$', re.MULTILINE | re.IGNORECASE)
+JEDI_BUNDLE_BRANCH_RE = re.compile(
+    r'^jedi-ci-bundle-branch\s?=\s?([a-zA-Z0-9\/:#\._-]{1,70})?\s*$', re.MULTILINE | re.IGNORECASE)
+MANIFEST_BRANCH_RE = re.compile(
+    r'^jedi-ci-manifest-branch\s?=\s?([a-zA-Z0-9\/:#\._-]{1,70})?\s*$', re.MULTILINE | re.IGNORECASE)
+
+
+@aws_client.ttl_lru_cache(ttl=5*60)
+def get_test_manifest(branch_arg: str, manifest_path: str = 'test_manifest.json'):
+    # Default branch used if the test description did not override this.
+    branch_name = os.environ.get('GITHUB_CI_REPO_BRANCH', 'develop')
+    if branch_arg:
+        branch_name = branch_arg
+    repo = GITHUB_CLIENT.get_repository('CI', 'JCSDA-internal')
+    contents = repo.get_contents(manifest_path, ref=branch_name)
+    json_content =  json.loads(contents.decoded_content)
+    return json_content
+
+
+class TestAnnotations(NamedTuple):
+    # A dict mapping repository names to pull request numbers. This map is
+    # used to generate the pull request build group.
+    build_group_map: Mapping[str, int]
+
+    # A string value representing a json boolean ("true" or "false"), this is
+    # passed to the build-info json file. If set to "true" the test runner will
+    # not read from the cache and will build all code.
+    skip_cache: str
+
+    # A string value representing a json boolean ("true" or "false"). This is
+    # passed to the build-info json file. If set to "true" the cache will be
+    # re-built.
+    rebuild_cache: str
+
+    # If False, tests will not be run for this change. This setting is used
+    # when evaluating draft pull requests which will not run by default but
+    # may be enabled with an annotation.
+    run_tests: bool
+
+    # If True, a 2-hour sleep will be added to the conclusion of a test.
+    debug_mode: bool
+
+    # Suffix used to select the CI environment. May be an empty sting or
+    # may be "-next" meaning that the "<env-name>-next" environment will be
+    # used for testing.
+    next_ci_suffix: str
+
+    # Selects which test to run, may be "random", "all", or one of the three
+    # valid build environments.
+    test_select: str
+
+    # Sets the jedi-bundle branch used for building the tests. If this value
+    # is not set (or set to an empty string) the test runner will checkout the
+    # default branch. This branch must exist in `JCSDA-internal/jedi-bundle`.
+    jedi_bundle_branch: str
+
+    # Set the CI test manifest config file branch used for evaluating the test
+    # dependencies. If this value is not set (or is set to an empty string) the
+    # lambda function will use the 'develop' branch. Any specified branch
+    # must exist in `JCSDA-internal/CI` or the test will fail to configure.
+    jedi_ci_manifest_branch: str
+
+
+def read_test_annotations(
+        repo_uri: str,
+        pr_number: int,
+        pr_payload: Union[Mapping[str, Any], None],
+        build_group_regex=BUILD_GROUP_RE,
+        cache_regex=CACHE_BEHAVIOR_RE,
+        draft_regex=DRAFT_PR_RUN_RE,
+        debug_regex=DEBUG_CI_RE,
+        test_select_regex=CI_TEST_SELECT_RE,
+        next_ci_regex=NEXT_CI_RE,
+        jedi_bundle_branch_regex=JEDI_BUNDLE_BRANCH_RE,
+        manifest_branch_regex=MANIFEST_BRANCH_RE,
+        ) -> TestAnnotations:
+    """Reads all jedi-ci specific behavior annotations from a pull request.
+
+    Returns a TestAnnotations named-tuple with all values set from the pull
+    request description or set to the default.
+    """
+    # Get the PR description if it was not provided by the caller.
+    if not pr_payload:
+        _validate_repo_uri(repo_uri=repo_uri)
+        repo, org = _repo_tuple_from_uri(repo_uri=repo_uri)
+        grepo = GITHUB_CLIENT.get_repository(repo, org)
+        pr_payload = grepo.get_pull(pr_number)._rawData
+        pr_body = pr_payload["body"]
+    else:
+        pr_body = pr_payload["body"]
+    # GitHub may use windows newlines (\r\n), this swap here ensures that no
+    # matter what newline type is returned, the text is evaluated with standard
+    # newlines.
+    pr_body = '\n'.join(pr_body.splitlines())
+    # Build Group
+    build_group_members = []
+    build_group_matches = build_group_regex.findall(pr_body)
+    for group_match in build_group_matches:
+        build_group_members.append(group_match)
+    print(f'Intermediate group matches: {build_group_members}')
+    build_group_pr_map = get_build_group_pr_map(build_group_members)
+    # Cache behavior: note that skip cache controls read behavior while
+    # rebuild_cache controls write behavior. The correct global behavior can
+    # be understood globally from the keyword used since rebuilding the cache
+    # requires also skipping cache lookup a user skipping the cache may not
+    # want their change to update the shared binary cache.
+    cache_behavior = cache_regex.findall(pr_body)
+    if cache_behavior and cache_behavior[0].lower() == 'skip':
+        skip_cache = 'true'
+        rebuild_cache = 'false'
+    elif cache_behavior and cache_behavior[0].lower() == 'rebuild':
+        skip_cache = 'true'
+        rebuild_cache = 'true'
+    else:
+        skip_cache = 'false'
+        rebuild_cache = 'false'
+    # Draft pull requests must be annotated for tests to run. If a pull request
+    # is a draft pull request, the tests will be skipped unless the author
+    # has added an annotation.
+    run_tests = False  # Start with negative assumption.
+    if not pr_payload.get('draft'):
+        run_tests = True  # Run tests if pr is not a draft.
+    else:
+        # Run tests if PR is a draft and annotated to run anyways.
+        draft_pr_note = draft_regex.findall(pr_body)
+        if draft_pr_note and draft_pr_note[0].lower() in ['t', 'true', 'yes']:
+            run_tests = True
+
+    # Check if debug mode is enabled.
+    debug_mode = bool(debug_regex.findall(pr_body))
+    # Check if "next" CI is enabled and set the suffix
+    next_ci = bool(next_ci_regex.findall(pr_body))
+    next_ci_suffix = '-next' if next_ci else ''
+
+    test_select_found = test_select_regex.findall(pr_body)
+    if test_select_found:
+        test_select = test_select_found[0]
+    else:
+        test_select = 'random'
+
+    # Determine if there is a nonstandard jedi-bundle branch. Finding any
+    # value here updates the cache behavior to skip since the bundle changes
+    # may alter the build dependency DAG.
+    bundle_branch_config = jedi_bundle_branch_regex.findall(pr_body)
+    bundle_branch = ''
+    if bundle_branch_config:
+        bundle_branch = bundle_branch_config[0]
+        skip_cache = 'true'  # Do not read from the cache.
+        rebuild_cache = 'false'  # Do not save build results to the cache.
+
+    # If an alternative manifest branch is set, fetch it. Finding any value
+    # here updates the cache behavior to skip since the manifest may contain
+    # conflicting cache directives.
+    manifest_branch_config = manifest_branch_regex.findall(pr_body)
+    manifest_branch = ''
+    if manifest_branch_config:
+        manifest_branch = manifest_branch_config[0]
+        skip_cache = 'true'  # Do not read from the cache.
+        rebuild_cache = 'false'  # Do not save build results to the cache.
+
+
+    return TestAnnotations(
+        build_group_map=build_group_pr_map,
+        skip_cache=skip_cache,
+        rebuild_cache=rebuild_cache,
+        run_tests=run_tests,
+        debug_mode=debug_mode,
+        next_ci_suffix=next_ci_suffix,
+        test_select=test_select,
+        jedi_bundle_branch=bundle_branch,
+        jedi_ci_manifest_branch=manifest_branch,
+    )
+
+
+def get_build_group_pr_map(build_group_members):
+    pr_map = {}
+    for member in build_group_members:
+        member_match = BUILD_GROUP_LINK.search(member)
+        if not member_match:
+            continue
+        owner, repo, pull_number = member_match.groups()
+        pr_map[f'{owner.lower()}/{repo.lower()}'] = int(pull_number)
+    return pr_map
+
+
+def gather_pr_group(test_manifest: dict, trigger_repo_key: str, curr_pr_id: str, pr_group_map):
+    group = []
+
+    # Loop over all repositories in the manifest. Later "continue" calls
+    # all come back here (the "repository loop").
+    for manifest_entry in test_manifest["repositories"]:
+        repo_uri = manifest_entry["uri"]
+        repo_manifest_name = manifest_entry["name"]
+        _validate_repo_uri(repo_uri=repo_uri)
+        repo_name, org = _repo_tuple_from_uri(repo_uri=repo_uri)
+        repo_name_key = org.lower() + '/' + repo_name.lower()
+
+        # External orgs (including public "jcsda") are not evaluated for
+        # pull request matching. We just use the identified release branch.
+        if org.lower() not in INTEGRATED_ORG_WHITELIST:
+            group.append(
+                {
+                    "name": repo_manifest_name,
+                    "uri": repo_uri,
+                    "version_ref": {
+                        "pr_id": "",
+                        "branch": manifest_entry['branch'],
+                    },
+                }
+            )
+            continue  # Continue the repository loop.
+
+        # This step only works for git repos with our app integration.
+        grepo = GITHUB_CLIENT.get_repository(repo_name, org)
+
+
+        # Handle self-reference differently (we already know pull #, etc).
+        if repo_name_key == trigger_repo_key:
+            pr = grepo.get_pull(curr_pr_id)
+            group.append(
+                {
+                    "name": repo_manifest_name,
+                    "uri": repo_uri,
+                    "version_ref": {
+                        "pr_id": pr.number,
+                        "branch": pr.head.ref,
+                        "commit": pr.head.sha,
+                    },
+                }
+            )
+            continue  # Continue the repository loop.
+
+        if repo_name_key in pr_group_map:
+            pr_number = pr_group_map[repo_name_key]
+            pr = grepo.get_pull(pr_number)
+            group.append(
+                    {
+                        "name": repo_manifest_name,
+                        "uri": repo_uri,
+                        "version_ref": {
+                            "pr_id": pr.number,
+                            "branch": pr.head.ref,
+                            "commit": pr.head.sha,
+                        },
+                    }
+                )
+            continue
+
+        # If there is no build group or no pull request that matches then we
+        # will get the default branch.
+        if 'branch' in manifest_entry:
+            default_branch = grepo.get_branch(manifest_entry['branch'])
+            ref_name = f'refs/heads/{manifest_entry["branch"]}'
+            commit_sha = default_branch.commit.sha
+        elif 'release_tag' in manifest_entry:
+            # Release tags can use the built-in version reference and only
+            # need to be configured if a pull request group is specified. This
+            # configuration is handled by the section that checks if the repo
+            # is in the `pr_group_map` dictionary.
+            continue
+
+        group.append(
+            {
+                "name": repo_manifest_name,
+                "uri": repo_uri,
+                "version_ref": {
+                    "pr_id": "",
+                    "branch": ref_name,
+                    "commit": commit_sha,
+                },
+            }
+        )
+    # Return the gathered manifest branch version references.
+    return group
+
+
+def get_prs(trigger_repo: str, trigger_uri: str, trigger_pr_id: str, trigger_commit: str, pr_payload: Union[Mapping[str, Any], None]):
+    """Evaluate a commit and configure tests based on the manifest and annotations.
+
+    Args:
+      trigger_repo: name of the triggering repository.
+      trigger_uri: https URI of the triggering repository.
+      trigger_pr_id: (string) the pull request number expressed as a string.
+      trigger_commit: full SHA hash of the trigger commit.
+
+    Returns a 3-tuple of:
+      build_info_payload: (dict) The "build info" json used to configure a test.
+      run_tests: (bool) go/no-go for tests.
+      test_select: string, may be one of {random, all, gcc, gcc11, intel}
+      job_suffix: Used as the suffix for the job definition. May be an
+                    empty string or "-next" to test updates to the CI
+                    environment.
+    """
+    test_annotations = read_test_annotations(
+        repo_uri=trigger_uri, pr_number=trigger_pr_id, pr_payload=pr_payload)
+
+    test_manifest = get_test_manifest(test_annotations.jedi_ci_manifest_branch)
+
+    # Get group name, test tags, and other attributes from current PR
+    real_repo_name, org = _repo_tuple_from_uri(repo_uri=trigger_uri)
+    repo_name_key = org.lower() + '/' + real_repo_name.lower()
+    current_repo_manifest = list(
+        filter(
+            lambda repo_manifest: repo_manifest["uri"].lower() == trigger_uri.lower(),
+            test_manifest["repositories"]
+        )
+    )[0]
+    # Retreive current repo uri
+    curr_repo_uri = current_repo_manifest["uri"]
+    curr_repo_manifest_name = current_repo_manifest["name"]
+    test_tag = current_repo_manifest.get("test_tag", "")
+
+
+    # If not running tests, return early to avoid unnecessary GitHub API calls.
+    if not test_annotations.run_tests:
+        return None, False, "", ""
+
+    print(f"Build group mapping found: {test_annotations.build_group_map}")
+    pr_group = gather_pr_group(
+        test_manifest, repo_name_key, trigger_pr_id, test_annotations.build_group_map)
+
+    build_info_payload = {
+        "trigger_pr_number": trigger_pr_id,
+        "trigger_commit_sha": trigger_commit,
+        "trigger_repo":  trigger_repo,
+        "manifest_name": curr_repo_manifest_name,
+        "test_tag": test_tag,
+        "dependencies": current_repo_manifest.get('dependencies', []),
+        "test_script": current_repo_manifest.get('test_script'),
+        "build_group": test_annotations.build_group_map,
+        "skip_cache": test_annotations.skip_cache,
+        "rebuild_cache": test_annotations.rebuild_cache,
+        "version_map": pr_group,
+        "debug_time": 120*60 if test_annotations.debug_mode else 0,
+        "jedi_bundle_branch": test_annotations.jedi_bundle_branch,
+    }
+
+
+    return (
+        build_info_payload,
+        True,
+        test_annotations.test_select,
+        test_annotations.next_ci_suffix,
+    )
+
+
+def _validate_repo_uri(repo_uri: str) -> str:
+    if not repo_uri.startswith(GITHUB_URI) and repo_uri.endswith(".git"):
+        raise ValueError(
+            f'Uri for {repo_name} is invalid. It should containt '
+            f'{GITHUB_URI} and end in .git.')
+
+
+def _get_fullname_from_uri(repo_uri: str) -> str:
+    """Converts https://github.com/org/repo.git into org/repo."""
+    return repo_uri[len(GITHUB_URI) : -4 : 1]
+
+
+def _repo_tuple_from_uri(repo_uri: str) -> str:
+    """Converts https://github.com/org/repo.git into a ("repo", "org") tuple."""
+    full_repo = _get_fullname_from_uri(repo_uri)
+    org, repo = full_repo.split('/', 1)
+    return repo, org

--- a/shell/environment.sh
+++ b/shell/environment.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+# This script is used to set environmental variables and create an environment
+# used by the CI system. It should be sourced into the CI runner script or
+# into the shell environment of someone looking to replicate a CI run.
+
+export CDASH_URL="https://cdash.jcsda.org"
+export SKIP_GITHUB_CHECK_RUNS='no'
+
+# ecbuild expects this to be set; various build templates are stored here.
+export jedi_cmake_ROOT=/opt/view
+
+# Additional exports for running OpenMPI MPI jobs as root
+# and with more resources than available
+export OMPI_ALLOW_RUN_AS_ROOT=1
+export OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1
+export OMPI_MCA_rmaps_base_oversubscribe=1
+
+# This timestamp is used to back-date source files to ensure that the later
+# `make` command sees the binary cache files as "fresh" and does not rebuild
+# the binaries. This procedure is necessary because tar archives preserve
+# modification date, so binaries are dated to the time they were archived.
+# Conversely, git does not preserve modification date, so source repositories
+# are dated to the time they are cloned.
+export SOURCE_BACKDATE_TIMESTAMP=$(date "+2020-%m-%dT%H:%M:%S")
+
+# Create directory structure for tests and saving important locations. Note
+# the jedi-bundle directory will be created by a later `git clone` command.
+echo "Setup testing folder structure and cloning jedi-bundle."
+if [ -z "$WORKDIR" ]; then
+    export WORKDIR="/workdir"
+fi
+if [ ! -d "${WORKDIR}" ]; then
+    mkdir -p "${WORKDIR}"
+fi
+mkdir "${WORKDIR}/test_root"
+mkdir "${WORKDIR}/test_root/build"
+mkdir "${WORKDIR}/test_root/build/module"
+export BUILD_DIR="${WORKDIR}/test_root/build"
+export TEST_ROOT="${WORKDIR}/test_root"
+export JEDI_BUNDLE_DIR="${WORKDIR}/test_root/jedi-bundle"
+export CI_CODE_PATH=$WORKDIR/CI
+export BUILD_PARALLELISM=5
+
+
+# Set compiler-specific flags and options specific to different tool chains. The
+# COMPILER_FLAGS array is used in the ecbuild invocation.
+export COMPILER_FLAGS=( )
+if [ $JEDI_COMPILER = "intel" ]; then
+    source /opt/intel/oneapi/compiler/latest/env/vars.sh
+    source /opt/intel/oneapi/mpi/latest/env/vars.sh
+    # Compiling with -O2 is too slow and uses too much memory
+    export COMPILER_FLAGS=( -DECBUILD_C_FLAGS_RELWITHDEBINFO=-O1 -DECBUILD_CXX_FLAGS_RELWITHDEBINFO=-O1 -DECBUILD_Fortran_FLAGS_RELWITHDEBINFO=-O1 )
+    export BUILD_PARALLELISM=4
+fi
+
+if [ $JEDI_COMPILER = "clang" ]; then
+    export CC=/usr/bin/clang
+    export CXX=/usr/bin/clang++
+fi
+
+if [ $JEDI_COMPILER = "gcc" ] || [ $JEDI_COMPILER = "gcc11" ]; then
+    export BUILD_PARALLELISM=4
+fi
+
+
+# Add compiler flags specific to individual repositories.
+if [ $TRIGGER_REPO = "ufo" ]; then
+  COMPILER_FLAGS+=( -DUFO_TEST_TIER=2 )
+fi
+
+
+# Make sure the private key is a file.
+if [ -n "$GITHUB_APP_PRIVATE_KEY" ]; then
+    if [ -f $GITHUB_APP_PRIVATE_KEY ]; then
+        # This is the configuration used to test this build script.
+        export GITHUB_APP_PRIVATE_KEY_FILE=$GITHUB_APP_PRIVATE_KEY
+    else
+        echo "writing private key to a file."
+        export GITHUB_APP_PRIVATE_KEY_FILE=$(mktemp -u)
+        echo "$GITHUB_APP_PRIVATE_KEY" > $GITHUB_APP_PRIVATE_KEY_FILE
+    fi
+else
+    echo "No value for \$GITHUB_APP_PRIVATE_KEY; skipping app auth config"
+fi
+
+# https://github.com/JCSDA-internal/mpas-jedi/issues/919
+rm -vf `find /opt/view/bin -iname '*esmf*'`
+rm -vf `find /opt/view/lib -iname '*esmf*'`
+rm -vf `find /opt/view/include -iname '*esmf*'`
+rm -vf `find /opt/view/cmake -iname '*esmf*'`

--- a/shell/github_api/check_run.py
+++ b/shell/github_api/check_run.py
@@ -1,0 +1,673 @@
+#!/usr/bin/env python3
+"""
+check_run.py manages the GitHub code check representation of our pre-submit
+tests. This script creates the check run, updates the check when tests
+start, and completes the check run when the tests are done.
+
+
+## Subcommands
+
+Commands for interacting with GitHub Check Runs.
+  * new:    Create a new GitHub check run. This will generate a standard
+            test name from the flags and will populate basic fields.
+  * update: Fine grained control of mutable check-run fields. This is used
+            for basic state updates and for adding the details URL.
+  * end:    Evaluate ctest results and advance a check run to complete status
+            while adding a test details document describing any observed
+            failures and linking to the test logs and cdash page.
+
+Other commands:
+  * eval_test_xml: Given a passing test percentage, determine if a Test.xml file
+                   meets the criteria for acceptance. Exit code of 1 if the test
+                   failure rate is above the test fail percentage.
+
+
+## Unresolved issues
+
+    - This needs to be updated to include info on build group.
+
+
+## What are check runs?
+
+  GitHub check runs are replacing the older commit status API. Check runs offer
+  more control over test result displays and status visible in the GitHub
+  Pull request UI. Some additional caveats to keep in mind.
+    - **NOTE**: Check runs can only be created by GitHub applications. They
+      cannot be created by user credentials.
+    - Run state (queued, running, complete) is updated separately from results.
+    - Results can include a title, a markdown document that will be rendered
+      GitHub UI, and (not used here) code annotations that will be rendered in
+      the pull request diff.
+
+    More information on GitHub check runs are available on GitHub's docs:
+    https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28
+
+
+## Examples:
+
+    # Create a new test in the queued state. If this command is successful it
+    # will print the check run ID to stdout.
+    $ CHECK_RUN_ID=$(
+        python3 check_run.py \
+            new \
+            --app-id=321331 \
+            --app-private-key=$HOME/.ssh/my_key.pem \
+            --repo=eap/skylab_env \
+            --commit=054d80255cb6351ae629f2caca3344537866e598 \
+            --test-type=unit \
+            --test-platform='arm' \
+            --test-logs-url="http://en.wikipedia.org/wiki/Shark")
+    $ echo $CHECK_RUN_ID
+    14633852039
+
+
+    # You can update some attributes of a check run using the 'update' command.
+    # This example sets the status to "in_progress" and updates the details
+    # url. Note the "title" is distinct from the test name and is shown after
+    # the state in GitHub. The test name cannot be edited.
+    $ python3 check_run.py \
+        update \
+        --app-id=321331 \
+        --app-private-key=$HOME/.ssh/my_key.pem \
+        --repo=eap/skylab_env \
+        --check-run-id=$CHECK_RUN_ID \
+        --status=in_progress \
+        --details-url="http://en.wikipedia.org/wiki/Sharknado" \
+        --title='Test is now Sharknado'
+
+     # In this 'update' example I am just changing the details URL and title
+     # without editing the state.
+     $ python3 ./check_run.py update \
+          --app-id=321331 \
+          --app-private-key=$HOME/.ssh/my_key.pem  \
+          --repo=eap/skylab_env \
+          --check-run-id=$CHECK_RUN_ID \
+          --details-url="http://en.wikipedia.org/wiki/Unit_testing" \
+          --title='Build environment allocated'
+
+    # It is also possible to set a simple conclusion using update.
+    $ python3 ./check_run.py update \
+          --app-id=321331 \
+          --app-private-key=$HOME/.ssh/my_key.pem  \
+          --repo=eap/skylab_env \
+          --check-run-id=$CHECK_RUN_ID \
+          --details-url="http://en.wikipedia.org/wiki/Unit_testing" \
+          --title='test skipped due to prior failure' \
+          --status=completed \
+          --conclusion=skipped
+
+    # Finalize test run with results from test output.
+    $ python3 check_run.py \
+        end \
+        --state-file=/tmp/test_config.json \
+        --test-xml=/home/build/Testing/20290101-1234/Test.xml \
+        --test-logs-url="http://en.wikipedia.org/wiki/Stingray" \
+        --max-failure-percentage=0
+"""
+
+import argparse
+import collections
+import json
+import os
+import requests
+import sys
+import textwrap
+import urllib.parse
+import xml.etree.ElementTree
+
+import github
+
+# Values needed when interacting with the GitHub API.
+ALLOWED_STATUSES = ['queued', 'in_progress', 'completed']
+ALLOWED_CONCLUSIONS = [
+    "action_required",
+    "cancelled",
+    "failure",
+    "neutral",
+    "success",
+    "skipped",
+    "stale",
+    "timed_out",
+]
+NotSet = github.GithubObject.NotSet
+
+
+# Arguments common to sub-commands.
+PARSER = argparse.ArgumentParser()
+
+SUBPARSERS = PARSER.add_subparsers(help='sub-command help')
+PARSER_NEW = SUBPARSERS.add_parser(
+    'new',
+    help='create a new queued check run for a commit to a repository.')
+PARSER_UPDATE = SUBPARSERS.add_parser(
+    'update',
+    help='Update an existing check run.')
+PARSER_END = SUBPARSERS.add_parser(
+    'end',
+    help='complete a check run, evaluate results adding the status and a '
+         'results document')
+
+
+# Common arguments for parsers that interact with the API.
+for subparser in [PARSER_NEW, PARSER_UPDATE, PARSER_END]:
+    subparser.add_argument(
+        '--app-id',
+        required=True,
+        help='The integer App ID for the GitHub application.')
+    subparser.add_argument(
+        '--app-private-key',
+        required=True,
+        help='File path to the app private key.')
+    subparser.add_argument(
+        '--repo',
+        required=True,
+        help='The repository path in the form of "user/repo-name".')
+
+
+PARSER_NEW.add_argument(
+    '--commit',
+    required=True,
+    help='The full commit hash of the test target.')
+PARSER_NEW.add_argument(
+    '--test-platform',
+    required=True,
+    help='The test platform used for test output and workflow titles.')
+PARSER_NEW.add_argument(
+    '--test-type',
+    required=True,
+    choices=['unit', 'integration'],
+    help='The test platform used for test output and workflow titles.')
+PARSER_NEW.add_argument(
+    '--ecs-metadata-uri',
+    default='',
+    help='URI for the AWS ECS metadata server (generally found using the '
+         'ECS_CONTAINER_METADATA_URI_V4 environment variable).')
+PARSER_NEW.add_argument(
+    '--batch-task-id',
+    default='',
+    help='The AWS Batch task ID.')
+
+
+PARSER_UPDATE.add_argument(
+    '--check-run-id',
+    required=True,
+    type=int,
+    help='The ID of the GitHub check run that will be edited.')
+PARSER_UPDATE.add_argument(
+    '--title',
+    required=True,
+    help='A title that will be displayed visibly in GitHub.')
+PARSER_UPDATE.add_argument(
+    '--status',
+    choices=ALLOWED_STATUSES,
+    help='status that will be applied to the check run. If setting "completed"'
+         'then --conclusion must also be set.')
+PARSER_UPDATE.add_argument(
+    '--conclusion',
+    choices=ALLOWED_CONCLUSIONS,
+    help='A test conclusion that will be set. This flag may only be supplied'
+         'if also setting --status=completed')
+PARSER_UPDATE.add_argument(
+    '--ecs-metadata-uri',
+    default='',
+    help='URI for the AWS ECS metadata server (generally found using the '
+         'ECS_CONTAINER_METADATA_URI_V4 environment variable).')
+PARSER_UPDATE.add_argument(
+    '--batch-task-id',
+    default='',
+    help='The AWS Batch task ID.')
+PARSER_UPDATE.add_argument(
+    '--public-log-link',
+    default='',
+    help='URL pointing to logs that can be accessed without AWS authentication')
+
+
+PARSER_END.add_argument(
+    '--check-run-id',
+    required=True,
+    type=int,
+    help='The ID of the GitHub check run that will be edited.')
+PARSER_END.add_argument(
+    '--test-xml',
+    required=True,
+    help='ctest output xml file with detailed test results.')
+PARSER_END.add_argument(
+    '--cdash-url',
+    required=True,
+    help='URL for the cdash output associated with this test.')
+PARSER_END.add_argument(
+    '--max-failure-percentage',
+    type=int,
+    required=True,
+    help='What percentage of tests may fail without failing the test.')
+PARSER_END.add_argument(
+    '--ecs-metadata-uri',
+    default='',
+    help='URI for the AWS ECS metadata server (generally found using the '
+         'ECS_CONTAINER_METADATA_URI_V4 environment variable).')
+PARSER_END.add_argument(
+    '--batch-task-id',
+    default='',
+    help='The AWS Batch task ID.')
+PARSER_END.add_argument(
+    '--public-log-link',
+    default='',
+    help='URL pointing to logs that can be accessed without AWS authentication')
+
+
+PARSER_EVAL = SUBPARSERS.add_parser('eval_test_xml', help='check if tests pass')
+# First argument is a hidden flag used to detect this state.
+PARSER_EVAL.add_argument(
+    '--eval-xml-flag',
+    action='store_true',
+    default=True,
+    help=argparse.SUPPRESS)
+PARSER_EVAL.add_argument(
+    '--test-xml',
+    required=True,
+    help='ctest output xml file with detailed test results.')
+PARSER_EVAL.add_argument(
+    '--max-failure-percentage',
+    type=int,
+    required=True,
+    help='What percentage of tests may fail without failing the test.')
+
+
+TEST_GENERAL_INFO = textwrap.dedent(f"""
+    ## CI System Information
+
+    A full explanation of all features, behaviors, and configuration options
+    can be found in the JEDI Infra knowledge base [article on CI](https://wiki.ucar.edu/display/JEDI/CI).
+
+    ## Quick reference
+
+    ```
+    Presubmit tests can be controlled by single-line annotations in the pull
+    request description. These annotations will be re-examined for each run.
+    Here is an example of their use:
+
+    # Build tests with other unsubmitted packages.
+    build-group=https://github.com/JCSDA-internal/oops/pull/2284
+    build-group=https://github.com/JCSDA-internal/saber/pull/651
+
+    # Disable the build-cache for tests.
+    jedi-ci-build-cache=skip
+
+    Each configuration setting must be on a single line, but order and
+    position does not matter.
+
+    # Enable tests for your draft PR (disabled by default).
+    run-ci-on-draft=true
+
+    # Use a specific compiler instead of selecting one at random.
+    # Must be "gcc", "gcc11", or "intel"
+    jedi-ci-test-select=gcc
+
+    # Select the jedi-bundle branch used for building. Using this option
+    # disables the build cache.
+    jedi-ci-bundle-branch=feature/my-bundle-change
+
+    ```
+""")
+
+
+
+class TestOutput(
+    collections.namedtuple('TestOutput', [
+        'all_tests',
+        'passed',
+        'not_passed',
+        'status_dict',
+        'not_passing_percent'
+    ])
+):
+    """Using a named-tuple to store Test.xml outputs."""
+
+    __slots__ = ()  # This is a tuple and needs no instance dict.
+
+    def format_not_passed_for_output(self, max_tests=30):
+        """convert the not_passed list to a useful output format."""
+        tests = []
+        for i, test_name in enumerate(self.not_passed):
+            test_status = self.status_dict[test_name]
+            tests.append(f'{test_name:.<80}..{test_status:.>10}')
+            if i + 1 == max_tests:
+                omitted = len(self.not_passed) - max_tests
+                tests.append(f'Omitting {omitted} results')
+                test_name = self.not_passed[-1]
+                test_status = self.status_dict[test_name]
+                tests.append(f'{test_name:.<80}..{test_status:.>10}')
+                break
+        return tests
+
+    @classmethod
+    def from_test_xml(cls, test_output_xml):
+        '''Parse the Test.xml file.
+
+        Once ctest completes a test run, it generates a file called "Test.xml".
+        this file summarizes the test results and gives details such as call
+        arguments, execution time, concurrency, and other configurable values.
+
+        This function parses the Test.xml file and fills test output values
+        used by this script to publish test results and set test status.
+        
+        The Test.xml file has the following structure (unused fields left out):
+
+             <Site>  // one
+                <Testing> // one
+                    <TestList> // one
+                        <Test>./path/to/package/test_full_name</Test> //repeats
+                    </TestList>
+                    <Test Status='somestatus'> // repeats
+                       <Name>test_name</Name>  // one
+                       ... other important test fields.
+                    </Test>
+                </Testing>
+            </Site>
+        '''
+        all_tests = []
+        passed_tests = []
+        not_passed = []
+        status_dict = {}
+
+        # Open the xml file.
+        tree = xml.etree.ElementTree.parse(test_output_xml)
+        root = tree.getroot()  # This is the "Site" element.
+
+        # Fetch the Testing child of Site. There is exactly one.
+        testing = root.find('Testing')
+        if testing is None:
+            raise ValueError('Test.xml file mssing <Testing> tag.')
+
+        # 'findall' iterates over direct children of an element with the given
+        # specific name. The direct-child relationship is important since
+        # TestList contains 'Test' elements with a different structure.
+        for i, test in enumerate(testing.findall('Test')):
+
+            # Get test name and add to all_tests.
+            name_elem = test.find('Name')
+            if name_elem is not None:
+                name = name_elem.text
+            else:
+                name = f'unknown_test_{i}'
+            all_tests.append(name)
+
+            # Check if test passed.
+            status = test.attrib.get('Status')
+            status_dict[name] = status
+            if status == 'passed':
+                passed_tests.append(name)
+            else:
+                not_passed.append(name)
+
+        if len(all_tests) == 0:
+            # This case is really undefined, but we need a number here. The
+            # caller should verify tests were run before using this property.
+            not_passing_percent = 100
+        else:
+            not_passing_percent = 100 * (len(not_passed) / float(len(all_tests)))
+
+        return cls(
+            all_tests,
+            passed_tests,
+            not_passed,
+            status_dict,
+            not_passing_percent)
+
+
+class ECSTaskMetaData(object):
+    """Class to fetch and query ECS Task MetaData from the MetaData server."""
+
+    def __init__(self, metadata_url=None, job_id=None):
+        """Query ECS metadata and init. Object gives dummy values if no URL."""
+        self._data = None
+        self._job_id = job_id
+        self._group = None
+        self._region = None
+        self._stream = None
+        # Get job data.
+        if metadata_url:
+            response = requests.get(f'{metadata_url}/task')
+            self._data = response.json()
+        if not self._data:
+            return
+        containers = self._data.get('Containers', [])
+        if not containers:
+            return
+        log_options = containers[0].get('LogOptions', None)
+        if not log_options:
+            return
+        self._group = log_options.get('awslogs-group')
+        self._region = log_options.get('awslogs-region')
+        self._stream = log_options.get('awslogs-stream')
+
+    def logs_url(self):
+        urlencoded_group = urllib.parse.quote_plus(self._group)
+        urlencoded_stream = urllib.parse.quote_plus(self._stream)
+        url = (f'https://{self._region}.console.aws.amazon.com/'
+               f'cloudwatch/home?region={self._region}#logsV2:log-groups/'
+               f'log-group/{urlencoded_group}/log-events/'
+               f'{urlencoded_stream}')
+        return url
+
+    def batch_task_url(self):
+        return (f'https://{self._region}.console.aws.amazon.com/'
+                f'batch/home?region={self._region}#jobs/detail/'
+                f'{self._job_id}')
+
+
+
+def get_authed_github_client(app_id, app_private_key, repo_owner, repo_name):
+    """Get an authorized client from a GitHub app ID, key, and repository."""
+    app_integration = github.GithubIntegration(
+        app_id,
+        app_private_key,
+        jwt_expiry=599,
+    )
+    installation = app_integration.get_repo_installation(repo_owner, repo_name)
+    auth = github.AppAuthentication(
+        app_id=app_id,
+        private_key=app_private_key,
+        installation_id=installation.id,
+    )
+    return github.Github(app_auth=auth)
+
+
+def _create_check_run(app_client, repo, commit, run_name, details_url=NotSet):
+    """Create a new GitHub check run."""
+    repo_object = app_client.get_repo(repo)
+    check_run = repo_object.create_check_run(
+        run_name,
+        commit,
+        details_url=details_url,
+        status='queued',
+    )
+    return check_run
+
+
+#
+# The following functions are receivers for the argparse subparsers.
+#
+
+
+def check_run_new(args, app_id, app_key, repo_owner, repo_name):
+    """Create a new check run. Used for "new" subparser."""
+    commit = args.commit
+    client = get_authed_github_client(
+        app_id, app_key, repo_owner, repo_name)
+    test_name = f'JEDI {args.test_type} test: {args.test_platform}'
+
+    metadata = ECSTaskMetaData(args.ecs_metadata_uri, args.batch_task_id)
+    run = _create_check_run(
+        app_client=client,
+        repo=f'{repo_owner}/{repo_name}',
+        commit=commit,
+        run_name=test_name,
+        details_url=metadata.batch_task_url())
+
+    print(f'{run.id}')
+
+
+def check_run_update(args, app_id, app_key, repo_owner, repo_name):
+    """Advance a check run's state from queued to running."""
+
+    # Validate a couple of mutually exclusive flag cases. These are documented
+    # in the help, but we must try to catch them here.
+    if args.status == 'completed' and not args.conclusion:
+        raise ValueError(
+            'When setting --status=completed a value for --conclusion '
+            'must also be included.')
+    if args.status != 'completed' and args.conclusion:
+        raise ValueError(
+            'When setting a value for --conclusion you must always set '
+            '--status=completed')
+    update_kwargs = {}
+
+    # Get the original check run.
+    run_id = args.check_run_id
+    client = get_authed_github_client(
+        app_id, app_key, repo_owner, repo_name)
+    repo = client.get_repo(f'{repo_owner}/{repo_name}')
+    check_run = repo.get_check_run(run_id)
+
+    test_info_links = ''  # Empty default will be overridden if possible.
+    if args.public_log_link:
+        test_info_links += f' * [Build logs]({args.public_log_link})\n'
+    # Get batch task info if present.
+    if args.batch_task_id:
+        metadata = ECSTaskMetaData(args.ecs_metadata_uri, args.batch_task_id)
+        update_kwargs['details_url'] = metadata.batch_task_url()
+        test_info_links += (
+            f' * [Test task]({metadata.batch_task_url()}) (requires AWS login)\n'
+            f' * [Test logs]({metadata.logs_url()}) (requires AWS login)\n\n')
+
+    output_md = f'## {check_run.name}\n\n' + test_info_links
+
+    if args.status:
+        update_kwargs['status'] = args.status
+    if args.conclusion:
+        update_kwargs['conclusion'] = args.conclusion
+
+    update_kwargs['output'] = {
+        'title': args.title,
+        'summary': '',
+        'text': output_md + TEST_GENERAL_INFO,
+    }
+
+    check_run.edit(**update_kwargs)
+    print(f'Successfully updated run {check_run.id}:\n'
+          f'{update_kwargs}')
+
+
+def check_run_end(args, app_id, app_key, repo_owner, repo_name):
+    """Update run state to complete and set conclusion from test XML output."""
+    run_id = args.check_run_id
+    # Validate and load args.
+    if args.max_failure_percentage > 100 or args.max_failure_percentage < 0:
+        raise ValueError(
+            'Flag --max-failure-percentage must be between 0 and 100')
+
+    # Get client.
+    client = get_authed_github_client(
+        app_id, app_key, repo_owner, repo_name)
+
+    # Summarize test results and make a pass/nopass conclusion.
+    results = TestOutput.from_test_xml(args.test_xml)
+    count_fail = len(results.not_passed)
+    count_pass = len(results.passed)
+    count_tests = len(results.all_tests)
+
+
+    # Get the check run first since the summary document requires
+    # info from the check run.
+    repo = client.get_repo(f'{repo_owner}/{repo_name}')
+    check_run = repo.get_check_run(run_id)
+    metadata = ECSTaskMetaData(args.ecs_metadata_uri, args.batch_task_id)
+
+    output_md = textwrap.dedent(f"""
+        ## {check_run.name}
+
+        Ran {count_tests} tests. Observed {count_pass} passing
+        tests and {count_fail} tests not passing.
+
+        * [CDash results for test]({args.cdash_url})
+        * [Build log]({args.public_log_link}) (available after job completes)
+        * [CI Job]({metadata.batch_task_url()}) (requires AWS login)
+        * [CI Job logs]({metadata.logs_url()}) (requires AWS login)
+
+    """)
+
+    if count_tests == 0:
+        conclusion = 'failure'
+        title = 'tests failed to run'
+    elif count_fail == 0:
+        conclusion = 'success'
+        title = f'ran {count_tests} tests'
+    # Here we can assume count_fail and count_tests is above zero.
+    else:
+        # If any failures are present (even for passing tests) we should
+        # summarize failures in our output document.
+        failure_summary = ['\n### Failures', '', '```']
+        for not_passed_line in results.format_not_passed_for_output():
+            failure_summary.append(f'{not_passed_line}')
+        output_md += '\n'.join(failure_summary) + '\n```\n'
+
+        if results.not_passing_percent <= args.max_failure_percentage:
+            conclusion = 'success'
+            title = (f'Success with some failures; {count_pass} of {count_tests} '
+                     'tests passing')
+        else:
+            conclusion = 'failure'
+            title = (f'Failure - {count_pass} of {count_tests} '
+                     'tests passing')
+    output_md = output_md + TEST_GENERAL_INFO
+    check_run.edit(
+        status='completed',
+        conclusion=conclusion,
+        output={'title': title, 'summary': '', 'text': output_md},
+        details_url=args.cdash_url)
+    print(f'Successfully updated run {check_run.id} to status "completed".')
+
+
+def eval_test_xml(args):
+    if args.max_failure_percentage > 100 or args.max_failure_percentage < 0:
+        raise ValueError(
+            'Flag --max-failure-percentage must be between 0 and 100')
+    results = TestOutput.from_test_xml(args.test_xml)
+
+    if len(results.all_tests) == 0:
+        print(f'tests failed to run.')
+        sys.exit(1)
+    elif results.not_passing_percent > args.max_failure_percentage:
+        print(f'Failure rate of {results.not_passing_percent:.1f}% is greater than '
+              f'the max failure percentage {args.max_failure_percentage}%.')
+        sys.exit(1)
+    sys.exit(0)
+
+
+def print_help(_):
+    PARSER.print_help()
+
+
+if __name__ == '__main__':
+    # Setting the arg "func" value must be done at the end of this file due to
+    # Python's lexical scoping of identifiers.
+    PARSER.set_defaults(func=print_help)
+    PARSER_NEW.set_defaults(func=check_run_new)
+    PARSER_UPDATE.set_defaults(func=check_run_update)
+    PARSER_END.set_defaults(func=check_run_end)
+    PARSER_EVAL.set_defaults(func=eval_test_xml)
+    args = PARSER.parse_args()
+
+    if 'eval_xml_flag' in args:
+        args.func(args)
+    else:
+        app_id = args.app_id
+        key_file = args.app_private_key
+        repo_owner, repo_name = args.repo.split('/')
+        if not os.path.isfile(key_file):
+            raise ValueError(f'No file found for -app-private-key "{key_file}".')
+        with open(key_file, 'r') as f:
+            app_key = f.read()
+
+        args.func(args, app_id, app_key, repo_owner, repo_name)

--- a/shell/github_api/generate_github_token.py
+++ b/shell/github_api/generate_github_token.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+import argparse
+import time
+import sys
+
+# Python has a bunch of jwt implementations, but PyJWT is by far the most used.
+# Unfortunately, calling "pip install jwt" will install a lesser used package
+# that breaks the GitHub API wrapper.
+try:
+    import jwt
+    from jwt import PyJWT
+except ImportError:
+    raise EnvironmentError(
+        'generate_github_token.py requires PyJWT>=2.0 and cannot use '
+        'the "jwt" library developed by Gehirn Inc. To fix this error '
+        'first uninstall jwt by running `pip3 uninstall jwt` then install '
+        'PyJWT by running `pip3 install PyJWT`.')
+
+# Args
+PARSER = argparse.ArgumentParser(
+    description='Generate a JWT for GitHub application authentication.')
+PARSER.add_argument(
+    '--pem-file',
+    required=True,
+    help='Path to the PEM file of the GitHub app private key.')
+PARSER.add_argument(
+    '--app-id',
+    required=True,
+    help='The ID of the GitHub application.')
+
+
+def generate_token(pem_file, app_id):
+    """Use a PEM key file and Application ID to generate a GitHub app JWT."""
+
+    with open(pem_file, 'r') as f:
+        key_text = f.read()
+
+    payload = {
+        # Issued at time, subtract 60 seconds to account for clock drift.
+        'iat': int(time.time()) - 60,
+        # JWT expiration time.
+        'exp': int(time.time()) + 600,
+        # GitHub App's identifier
+        'iss': app_id
+    }
+
+    encoded_jwt = jwt.encode(payload, key_text, algorithm='RS256')
+    if isinstance(encoded_jwt, bytes):
+        encoded_jwt = encrypted.decode("utf-8")
+    return encoded_jwt
+
+
+if __name__ == '__main__':
+    args = PARSER.parse_args()
+    encoded_jwt = generate_token(args.pem_file, args.app_id)
+    print(f"{encoded_jwt}")

--- a/shell/run_tests_integration.sh
+++ b/shell/run_tests_integration.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+
+# This script runs integration tests for the JEDI CI system. Unlike the other
+# test runner script in this project, this will automatically mark unit tests
+# as passed and will directly run integration tests. It will still evaluate
+# the build information and assemble a specific build group based on the
+# change that started this test.
+
+#
+# Environment validation and variable definitions.
+#
+
+# Load common function definitions.
+source $WORKDIR/CI/src/test_runner/util.sh
+source $WORKDIR/CI/src/test_runner/environment.sh
+
+# Return code for any line of shell code containing a pipe or redirect will
+# come from the inner-most executable command.
+set -o pipefail
+
+# Validate environment.
+valid_environment_found="yes"
+
+if [ -z $GITHUB_APP_PRIVATE_KEY ]; then
+    echo "Var GITHUB_APP_PRIVATE_KEY must be set and must contain the text of the GitHub App private key or a file path of the key"
+    valid_environment_found="no"
+fi
+if [ -z $GITHUB_APP_ID ]; then
+    echo "Var GITHUB_APP_ID must be set and must contain the GitHub App ID"
+    valid_environment_found="no"
+fi
+if [ -z $GITHUB_INSTALL_ID ]; then
+    echo "Var GITHUB_INSTALL_ID must be set and must contain the GitHub App install ID used for API access with target repositories."
+    valid_environment_found="no"
+fi
+if [ -z $BUILD_INFO_B64 ]; then
+    echo "Var BUILD_INFO_B64 must be set; it should be a base64 encoded gzipped json string with build configuration and dependency versions."
+    valid_environment_found="no"
+fi
+if [ -z "${JEDI_COMPILER}" ]; then
+    echo "Var JEDI_COMPILER must be set. This variable must be the name of the build environment toolchain."
+    valid_environment_found="no"
+fi
+if [ -z $AWS_BATCH_JOB_ID ]; then
+    # This variable is set by AWS Batch.
+    echo "Var AWS_BATCH_JOB_ID must be set.."
+    valid_environment_found="no"
+fi
+if [ -z "${ECS_CONTAINER_METADATA_URI_V4}" ]; then
+    # This variable is set by AWS Batch.
+    echo "Var ECS_CONTAINER_METADATA_URI_V4 must be set."
+    valid_environment_found="no"
+fi
+
+
+if [ $valid_environment_found == "no" ]; then
+    exit 1
+fi
+
+cat << EOF
+Configuration:
+GITHUB_APP_PRIVATE_KEY_FILE=${GITHUB_APP_PRIVATE_KEY_FILE}
+GITHUB_APP_ID=${GITHUB_APP_ID}
+GITHUB_INSTALL_ID=${GITHUB_INSTALL_ID}
+BUILD_PARALLELISM=${BUILD_PARALLELISM}
+WORKDIR=${WORKDIR}
+CDASH_URL=${CDASH_URL}
+jedi_cmake_ROOT=${jedi_cmake_ROOT}
+OMPI_ALLOW_RUN_AS_ROOT=${OMPI_ALLOW_RUN_AS_ROOT}
+OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=${OMPI_ALLOW_RUN_AS_ROOT_CONFIRM}
+OMPI_MCA_rmaps_base_oversubscribe=${OMPI_MCA_rmaps_base_oversubscribe}
+CI_CODE_PATH=${CI_CODE_PATH}
+CC="${CC}"
+CXX="${CXX}"
+EOF
+
+
+# From this point forward we are executing the test and sending debug to stderr.
+set -x
+
+
+#
+# Setup and run tests.
+#
+
+# Starting here we need to clone several things from GitHub, altough all
+# git operations should take far less than the 10 minute life of this token.
+
+
+
+# The lambda function has generated a json job config and passed it to this test
+# script as "BUILD_INFO_B64" after zipping and base64 encoding it. This step
+# decodes the job config json, and extracts several important config values.
+BUILD_JSON=$(mktemp)
+echo $BUILD_INFO_B64 | base64 --decode | gunzip > $BUILD_JSON
+TRIGGER_REPO=$(jq -r '.trigger_repo' $BUILD_JSON)
+TRIGGER_MANIFEST_NAME=$(jq -r '.manifest_name' $BUILD_JSON)
+UNITTEST_TAG=$(jq -r '.test_tag' $BUILD_JSON)
+TRIGGER_SHA=$(jq -r '.trigger_commit_sha' $BUILD_JSON)
+TRIGGER_PR=$(jq -r '.trigger_pr_number' $BUILD_JSON)
+TRIGGER_REPO_FULL="JCSDA-internal/${TRIGGER_REPO}"
+INTEGRATION_RUN_ID="$(jq -r ".check_runs.integration" $BUILD_JSON)"
+UNIT_RUN_ID="$(jq -r ".check_runs.unit" $BUILD_JSON)"
+REFRESH_CACHE_ON_FETCH="$(jq -r ".skip_cache" $BUILD_JSON)"
+REFRESH_CACHE_ON_WRITE="$(jq -r ".rebuild_cache" $BUILD_JSON)"
+JEDI_BUNDLE_BRANCH="$(jq -r ".jedi_bundle_branch" $BUILD_JSON)"
+
+
+# Generate the version ref flag value used later for build config. Ignore
+# entries with null version_ref.commit values they are branch references already
+# configured in the bundle.
+VERSION_MAP=$(jq -j '[.version_map[] | select(.version_ref.commit != null) | "\(.name)=\(.version_ref.commit)" ] | join(" ")' $BUILD_JSON)
+UNIT_DEPENDENCIES=$(jq -r '.dependencies | join(" ")' $BUILD_JSON)
+
+
+if [ "${CREATE_CHECK_RUNS}" == "yes" ]; then
+    UNIT_RUN_ID=$(util.check_run_new $TRIGGER_REPO_FULL "unit" $TRIGGER_SHA)
+    INTEGRATION_RUN_ID=$(util.check_run_new $TRIGGER_REPO_FULL "integration" $TRIGGER_SHA)
+fi
+
+# Update check-runs to include the batch job URL is included.
+util.check_run_successful_skip $TRIGGER_REPO_FULL $UNIT_RUN_ID
+util.check_run_start_build $TRIGGER_REPO_FULL $INTEGRATION_RUN_ID
+
+if [ -n "${JEDI_BUNDLE_BRANCH}" ]; then
+    git clone https://github.com/JCSDA-internal/jedi-bundle.git -b "${JEDI_BUNDLE_BRANCH}" "${JEDI_BUNDLE_DIR}"
+else
+    git clone https://github.com/JCSDA-internal/jedi-bundle.git "${JEDI_BUNDLE_DIR}"
+fi
+
+# Configure cdash integration.
+mkdir "${JEDI_BUNDLE_DIR}/cmake"
+cp "${WORKDIR}/CI/src/configure_bundle/ctest_assets/CTestConfig.cmake"       "${JEDI_BUNDLE_DIR}/"
+cp "${WORKDIR}/CI/src/configure_bundle/ctest_assets/CTestCustom.ctest.in"    "${JEDI_BUNDLE_DIR}/cmake/"
+cp "${WORKDIR}/CI/src/configure_bundle/ctest_assets/cdash-integration.cmake" "${JEDI_BUNDLE_DIR}/cmake/"
+sed -i "s#CDASH_URL#${CDASH_URL}#g"           "${JEDI_BUNDLE_DIR}/CTestConfig.cmake"
+sed -i "s#TEST_TARGET_NAME#${TRIGGER_REPO}#g" "${JEDI_BUNDLE_DIR}/CTestConfig.cmake"
+echo "include(cmake/cdash-integration.cmake)" >> "${JEDI_BUNDLE_DIR}/CMakeLists.txt"
+echo ""                                       >> "${JEDI_BUNDLE_DIR}/CMakeLists.txt"
+echo "include(CTest)"                         >> "${JEDI_BUNDLE_DIR}/CMakeLists.txt"
+echo ""                                       >> "${JEDI_BUNDLE_DIR}/CMakeLists.txt"
+
+
+$WORKDIR/CI/src/configure_bundle/configure_bundle.py \
+  --integration-test \
+  --test-target $TRIGGER_MANIFEST_NAME \
+  --dependency-version $VERSION_MAP \
+  --bundle-root="${JEDI_BUNDLE_DIR}"
+
+echo "---- JEDI Bundle CMakeLists.txt -----"
+cat $JEDI_BUNDLE_DIR/CMakeLists.txt
+
+if [ $? -ne 0 ]; then
+    util.check_run_fail $TRIGGER_REPO_FULL $INTEGRATION_RUN_ID "Bundle configuration failed"
+    exit 0
+fi
+
+# Fetch any pre-built artifacts from the build cache.
+$WORKDIR/CI/src/test_runner/binary_cache.py fetch \
+    --build-info-json $BUILD_JSON \
+    --test-manifest $WORKDIR/CI/test_manifest.json \
+    --cache-bucket jcsda-usaf-ci-build-cache \
+    --container-version ${CONTAINER_VERSION:-latest} \
+    --compiler $JEDI_COMPILER \
+    --platform "$(uname)-$(uname -p)-batch" \
+    --refresh-cache $REFRESH_CACHE_ON_FETCH \
+    --build-directory $BUILD_DIR
+
+ecbuild \
+      -Wno-dev \
+      -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+      -DCDASH_OVERRIDE_SYSTEM_NAME="${JEDI_COMPILER}-Container" \
+      -DCDASH_OVERRIDE_SITE=AWSBatch \
+      -DCDASH_OVERRIDE_GIT_BRANCH=${TRIGGER_PR} \
+      -DCTEST_UPDATE_VERSION_ONLY=FALSE \
+      -DBUILD_IODA_CONVERTERS=ON \
+      -DBUILD_PYIRI=ON \
+      ${COMPILER_FLAGS[@]} "${JEDI_BUNDLE_DIR}"
+if [ $? -ne 0 ]; then
+    util.check_run_fail $TRIGGER_REPO_FULL $INTEGRATION_RUN_ID "ecbuild failed"
+    exit 0
+fi
+
+# Back-date source files (search "back-date" in this file for an explanation).
+find $JEDI_BUNDLE_DIR -type f -exec touch -d "$SOURCE_BACKDATE_TIMESTAMP" {} \;
+
+make -j $BUILD_PARALLELISM
+if [ $? -ne 0 ]; then
+    util.check_run_fail $TRIGGER_REPO_FULL $INTEGRATION_RUN_ID "compilation failed"
+    exit 0
+fi
+
+util.check_run_start_test $TRIGGER_REPO_FULL $INTEGRATION_RUN_ID
+
+# Run tests.
+ctest -LE "gsibec|rttov|oasim|ropp-ufo" --timeout 180 -C RelWithDebInfo -D ExperimentalTest
+
+# Upload ctests.
+ctest -C RelWithDebInfo -D ExperimentalSubmit -M Continuous -- --track Continuous --group Continuous
+
+find ${BUILD_DIR}/Testing -type f
+find ${BUILD_DIR}/Testing -type f -exec head -n5 {} \;
+
+echo "CDash URL: $(util.create_cdash_url "${BUILD_DIR}/Testing")"
+TEST_TAG=$(head -1 "${BUILD_DIR}/Testing/TAG")
+ls -al "${BUILD_DIR}/Testing/${TEST_TAG}/"
+
+# Complete unit tests with max failure percentage of 3
+util.check_run_end $TRIGGER_REPO_FULL $INTEGRATION_RUN_ID 3
+
+# Sleep at the end of execution if debug mode is enabled.
+if [ -n "${DEBUG_TIME_SECONDS}" ]; then
+    sleep $DEBUG_TIME_SECONDS
+fi

--- a/shell/util.sh
+++ b/shell/util.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+#
+# Function definitions.
+#
+
+# Used by any exit clauses of the script, this function will first check if
+# a debug sleep is enabled (allowing users time to log-in and inspect tests
+# environments), then the work directory is cleared allowing the script to
+# exit without consuming additional storage.
+util.evaluate_debug_timer_then_cleanup() {
+    # Sleep at the end of execution if debug mode is enabled.
+    if [ -n "${DEBUG_TIME_SECONDS}" ]; then
+        echo "Debug mode is enabled, sleeping for ${DEBUG_TIME_SECONDS} seconds"
+        sleep $DEBUG_TIME_SECONDS
+    fi
+    # Clear workdir
+    rm -rf ${WORKDIR}/*
+}
+
+
+# Find the Test.xml file. Under some circumstances the Test.xml file may
+# be in an unexpected location, this function attempts to find the file at
+# the expected location, then expands the search if it is not found
+# See this bug for more information on why this function is needed:
+#  - https://github.com/JCSDA-internal/CI/issues/56
+util.find_test_xml() {
+    test_tag=$(head -1 "${BUILD_DIR}/Testing/TAG")
+    expected_file="${BUILD_DIR}/Testing/${test_tag}/Test.xml"
+    if [ -f "${expected_file}" ]; then
+        echo "${expected_file}"
+        return 0
+    fi
+    # Infer here that the file was not found at the expected tag location,
+    # use find to look for the file.
+    found_file="$(find ${BUILD_DIR}/Testing -type f -name "Test.xml" | head -n1)"
+    if [ -f "${found_file}" ]; then
+        echo "${found_file}"
+    else
+        # This case is very rare and is associated with build errors that are
+        # detected earlier. If this happens, we just update the string to make
+        # later errors more obvious.
+        echo "no-file-found-for-Test.xml"
+    fi
+}
+
+# Generate a cdash url using the upload output xml.
+util.create_cdash_url() {
+    test_dir=$1
+    tag=$(head -1 "${test_dir}/TAG")
+    Done=$(cat "${test_dir}/${tag}/Done.xml")
+    buildID=$(echo $Done | grep -o -P '(?<=buildId>).*(?=</build)')
+    echo "${CDASH_URL}/viewTest.php?buildid=$buildID"
+}
+
+# Create a new check run in the queued state.
+# Takes three arguments:
+#     $1: Repository name in "owner/repo" format.
+#     $2: Test-type; must be "unit" or "integration"
+#     $3: trigger commit sha hash.
+util.check_run_new() {
+    if [ $SKIP_GITHUB_CHECK_RUNS = 'yes' ]; then
+        return 0
+    fi
+    repo=$1
+    test_type=$2
+    commit_sha=$3
+    $CI_CODE_PATH/src/test_runner/github_api/check_run.py new \
+        --app-private-key="${GITHUB_APP_PRIVATE_KEY_FILE}" \
+        --app-id="${GITHUB_APP_ID}" \
+        --repo=$repo \
+        --commit=$commit_sha \
+        --test-type=$test_type \
+        --test-platform=${JEDI_COMPILER} \
+        --ecs-metadata-uri="${ECS_CONTAINER_METADATA_URI_V4}" \
+        --batch-task-id="${AWS_BATCH_JOB_ID}"
+}
+
+# Update a queued check-run with a link to the runner. This is used as
+# a hand-off from the lambda function which does not yet have a link to
+# the runner logs. Args:
+#     $1: Repository name in "owner/repo" format.
+#     $2: Check Run ID: the identifier from GitHub's API.
+util.check_run_runner_allocated() {
+    if [ $SKIP_GITHUB_CHECK_RUNS = 'yes' ]; then
+        return 0
+    fi
+    repo=$1
+    run_id=$2
+    # Note: when the test is updated to indicate a runner is allocated we do
+    # not include the public log link since it is not available until after all
+    # tests on a build host are complete.
+    $CI_CODE_PATH/src/test_runner/github_api/check_run.py update \
+        --app-private-key="${GITHUB_APP_PRIVATE_KEY_FILE}" \
+        --app-id="${GITHUB_APP_ID}" \
+        --repo=$repo \
+        --check-run-id="${run_id}" \
+        --ecs-metadata-uri="${ECS_CONTAINER_METADATA_URI_V4}" \
+        --batch-task-id="${AWS_BATCH_JOB_ID}" \
+        --title="Test runner allocated"
+}
+
+# Update a check run setting the status to failure and giving a simple
+# reason for the failure like "compile failed" or similar. Args:
+#     $1: Repository name in "owner/repo" format.
+#     $2: Check Run ID: the identifier from GitHub's API.
+#     $3: Failure reason string.
+util.check_run_fail() {
+    if [ $SKIP_GITHUB_CHECK_RUNS = 'yes' ]; then
+        return 0
+    fi
+    repo=$1
+    run_id=$2
+    fail_reason=$3
+    $CI_CODE_PATH/src/test_runner/github_api/check_run.py update \
+        --app-private-key="${GITHUB_APP_PRIVATE_KEY_FILE}" \
+        --app-id="${GITHUB_APP_ID}" \
+        --repo=$repo \
+        --check-run-id="${run_id}" \
+        --ecs-metadata-uri="${ECS_CONTAINER_METADATA_URI_V4}" \
+        --batch-task-id="${AWS_BATCH_JOB_ID}" \
+        --public-log-link="${PUBLIC_LOG_URL}" \
+        --status="completed" \
+        --conclusion="failure" \
+        --title="${fail_reason}"
+}
+
+# Update a check run to have a status of "complete" and a conclusion of
+# "skipped". This is a soft failure mode and notes a failure upstream from
+# the skipped test. Repositories with skipped check runs will not permit
+# code to be merged.
+# Args:
+#     $1: Repository name in "owner/repo" format.
+#     $2: Check Run ID: the identifier from GitHub's API.
+util.check_run_skip() {
+    if [ $SKIP_GITHUB_CHECK_RUNS = 'yes' ]; then
+        return 0
+    fi
+    repo=$1
+    run_id=$2
+    $CI_CODE_PATH/src/test_runner/github_api/check_run.py update \
+        --app-private-key="${GITHUB_APP_PRIVATE_KEY_FILE}" \
+        --app-id="${GITHUB_APP_ID}" \
+        --repo=$repo \
+        --check-run-id="${run_id}" \
+        --ecs-metadata-uri="${ECS_CONTAINER_METADATA_URI_V4}" \
+        --batch-task-id="${AWS_BATCH_JOB_ID}" \
+        --public-log-link="${PUBLIC_LOG_URL}" \
+        --status="completed" \
+        --conclusion="skipped" \
+        --title="prior step failed"
+}
+
+# Update a check run to have a status of "complete" and a conclusion of
+# "success". This type of update is used to skip a test that is not required
+# but would otherwise cause the repository to block merging.
+# Args:
+#     $1: Repository name in "owner/repo" format.
+#     $2: Check Run ID: the identifier from GitHub's API.
+util.check_run_successful_skip() {
+    if [ $SKIP_GITHUB_CHECK_RUNS = 'yes' ]; then
+        return 0
+    fi
+    repo=$1
+    run_id=$2
+    $CI_CODE_PATH/src/test_runner/github_api/check_run.py update \
+        --app-private-key="${GITHUB_APP_PRIVATE_KEY_FILE}" \
+        --app-id="${GITHUB_APP_ID}" \
+        --repo=$repo \
+        --check-run-id="${run_id}" \
+        --ecs-metadata-uri="${ECS_CONTAINER_METADATA_URI_V4}" \
+        --batch-task-id="${AWS_BATCH_JOB_ID}" \
+        --public-log-link="${PUBLIC_LOG_URL}" \
+        --status="completed" \
+        --conclusion="success" \
+        --title="no required tests"
+}
+
+# Update a queued check-run setting its status to 'in_progress' and
+# details title to "building". Also attach a link to the build logs.
+# Args:
+#     $1: Repository name in "owner/repo" format.
+#     $2: Check Run ID: the identifier from GitHub's API.
+util.check_run_start_build() {
+    if [ $SKIP_GITHUB_CHECK_RUNS = 'yes' ]; then
+        return 0
+    fi
+    repo=$1
+    run_id=$2
+    # As with runner_allocated we don't include the public log link.
+    $CI_CODE_PATH/src/test_runner/github_api/check_run.py update \
+        --app-private-key="${GITHUB_APP_PRIVATE_KEY_FILE}" \
+        --app-id="${GITHUB_APP_ID}" \
+        --repo=$repo \
+        --check-run-id="${run_id}" \
+        --status="in_progress" \
+        --ecs-metadata-uri="${ECS_CONTAINER_METADATA_URI_V4}" \
+        --batch-task-id="${AWS_BATCH_JOB_ID}" \
+        --title='building'
+}
+
+# Update a queued check-run setting its status to 'in_progress' and
+# details title to "testing". Also attach a link to the build logs.
+# Args:
+#     $1: Repository name in "owner/repo" format.
+#     $2: Check Run ID: the identifier from GitHub's API.
+util.check_run_start_test() {
+    if [ $SKIP_GITHUB_CHECK_RUNS = 'yes' ]; then
+        return 0
+    fi
+    repo=$1
+    run_id=$2
+    # As with runner_allocated we don't include the public log link.
+    $CI_CODE_PATH/src/test_runner/github_api/check_run.py update \
+        --app-private-key="${GITHUB_APP_PRIVATE_KEY_FILE}" \
+        --app-id="${GITHUB_APP_ID}" \
+        --repo="${repo}" \
+        --check-run-id="${run_id}" \
+        --status="in_progress" \
+        --ecs-metadata-uri="${ECS_CONTAINER_METADATA_URI_V4}" \
+        --batch-task-id="${AWS_BATCH_JOB_ID}" \
+        --title='testing'
+}
+
+# Update a queued check-run setting its status to 'complete' and set
+# the conclusion based on the contents of the Test.xml file and a maximum
+# failure rate. Additionally this will author a summary markdown
+# document that will be rendered in the GitHub UI.
+# Args:
+#     $1: Repository name in "owner/repo" format.
+#     $2: Check Run ID: the identifier from GitHub's API.
+#     $3: (integer) The max allowed failure percentage.
+util.check_run_end() {
+    if [ $SKIP_GITHUB_CHECK_RUNS = 'yes' ]; then
+        return 0
+    fi
+    repo=$1
+    run_id=$2
+    max_fail_ppc=$3
+    cdash_url=$(util.create_cdash_url "${BUILD_DIR}/Testing")
+    test_xml=$(util.find_test_xml)
+    $CI_CODE_PATH/src/test_runner/github_api/check_run.py end \
+        --app-private-key="${GITHUB_APP_PRIVATE_KEY_FILE}" \
+        --app-id="${GITHUB_APP_ID}" \
+        --repo="${repo}" \
+        --check-run-id="${run_id}" \
+        --test-xml="${test_xml}" \
+        --max-failure-percentage $max_fail_ppc \
+        --cdash-url="${cdash_url}" \
+        --public-log-link="${PUBLIC_LOG_URL}" \
+        --ecs-metadata-uri="${ECS_CONTAINER_METADATA_URI_V4}" \
+        --batch-task-id="${AWS_BATCH_JOB_ID}"
+}
+
+
+# This function checks the Test.xml file to determine if we should mark the test
+# as passed or failed. This is used for bash-logic, not for cdash or check-run
+# outputs. Takes no arguments. This only runs after the unit tests.
+# Args:
+#     $1: (integer) The max allowed failure percentage.
+util.check_run_eval_test_xml() {
+    max_fail_ppc=$1
+    if [ $SKIP_GITHUB_CHECK_RUNS = 'yes' ]; then
+        return 0
+    fi
+    test_xml=$(util.find_test_xml)
+    if $CI_CODE_PATH/src/test_runner/github_api/check_run.py eval_test_xml \
+            --test-xml="${test_xml}" \
+            --max-failure-percentage $max_fail_ppc
+    then
+        return 0
+    fi
+    return 1
+}


### PR DESCRIPTION
This is the initial re-organization of the CI codebase and can be rubber stamped without closely reviewing the code. What matters here is organization. I have moved around a variety of files from the original repository without edits so that subsequent pull requests can focus on changes.

### Files moved:

| CI (original location) | jedi-ci (this repository)  |
| - | - |
| src/github_webhooks_lambda/* | ci_action/* |
| src/github_webhooks_lambda/lambda_function.py | ci_action/implementation.py |
| src/test_runner/* | shell/* |
| src/test_runner/github_api/* | shell/github_api/* |

### Final directory structure
```
LICENSE
README.md
ci_action/
  __init__.py
  implementation.py
  library/
    aws_client.py
    github_client.py
    pr_resolve.py
shell/
  environment.sh
  run_tests_integration.sh
  util.sh
  github_api/
    check_run.py
    generate_github_token.py
```

