### PR TITLE
Add cmake_rewrite.py and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+

--- a/ci_action/__init__.py
+++ b/ci_action/__init__.py
@@ -1,2 +1,1 @@
 from .main import main
-from . import implementation

--- a/ci_action/library/cmake_rewrite.py
+++ b/ci_action/library/cmake_rewrite.py
@@ -1,0 +1,288 @@
+"""
+This is a tool to rewrite the CMakeLists.txt file by
+parsing and rewriting the ecbuild_bundle() calls with
+injected references
+
+For reference, the general form of the ecbuild_bundle() call is:
+
+   ecbuild_bundle( PROJECT <name>
+                   STASH <repository> | GIT <giturl> | SOURCE <path>
+                   [ BRANCH <gitbranch> | TAG <gittag> ]
+                   [ UPDATE | NOREMOTE ]
+                   [ MANUAL ]
+                   [ RECURSIVE ] )
+   Example:
+       ecbuild_bundle( PROJECT myproject GIT "https://github.com/myorg/myrepo.git" BRANCH mybranch UPDATE RECURSIVE )
+
+Since STASH is deprecated and is not supported by jedi-bundle or any
+JEDI software this tool does not allow STASH to be used. All other
+syntax is supported and GitHub repositories can be rewritten using the
+CMakeFile class.
+"""
+from dataclasses import dataclass
+from collections.abc import Container
+from typing import Optional, Dict, Any
+import re
+
+from ci_action.library import github_client
+@dataclass
+class BundleLinePart:
+    name: str
+    # True if the component is an attribute like "UPDATE" or "RECURSIVE", False if it is a value.
+    is_attribute: bool
+    # The value of the component if it is not an attribute.
+    value: str = None
+    quote_char: str = str() # Defaults to empty string
+
+    def __str__(self):
+        #if self.name == "PROJECT":
+        #    raise ValueError(f"PROJECT found!! {self.name} {self.quote_char}{self.value}{self.quote_char}... also isattrubute: {self.is_attribute}")
+        if self.is_attribute:
+            return f"{self.name}"
+        else:
+            return f"{self.name} {self.quote_char}{self.value}{self.quote_char}"
+
+
+class BundleLine:
+
+    _project_re = re.compile(r"^\s*ecbuild_bundle\(\s*PROJECT\s+([a-zA-Z0-9._-]*)\s+")
+    _git_re = re.compile(r".*GIT\s+[\"']([a-zA-Z0-9/:._-]+)[\"']\s")
+    _source_re = re.compile(r".*SOURCE\s+([a-zA-Z0-9/:._-]+)\s")
+    _branch_or_tag_re = re.compile(r".*(BRANCH|TAG)\s+([a-zA-Z0-9._-]+)\s")
+    _remote_rule_re = re.compile(r".*(UPDATE|NOREMOTE)\s")
+    _manual_and_recursive_re = re.compile(r".*(MANUAL|RECURSIVE)\s")
+
+    def __init__(self, content: str):
+        self.content = content
+        self.source_reference_type = None  # this will be set to "git" or "source"
+        self.source_reference = None
+
+        # During rewriting, we will check lines against rewrite rules stored as
+        # a keyed value of "orgname/reponame" -> "updated_tag".
+        self.github_org_repo_key = None
+
+        self.version_ref_type = None  # this will be set to "branch" or "tag"
+        self.version_ref = None
+
+        self.remote_rule = None
+
+        self.project = None
+        self.components = []
+
+        # Parse the project name
+        match = self._project_re.match(content)
+        if not match:
+            raise ValueError(f"Invalid bundle; no project name\n {content}")
+        self.project = BundleLinePart("PROJECT", False, match.group(1))
+        self.project_name = match.group(1)
+
+        # Parsing the git url or source path, these must be present and are mutually exclusive.
+        # Parse the git url
+        match = self._git_re.match(content)
+        if match:
+            self.source_reference = BundleLinePart("GIT", False, match.group(1), quote_char='"')
+            self.source_reference_type = "git"
+            git_uri = match.group(1).lower()
+            if 'github.com' in git_uri:
+                repo, org = github_client.get_repo_tuple_from_github_uri(git_uri)
+                self.github_org_repo_key = f'{org}/{repo}'
+        # Parse the source path
+        match = self._source_re.match(content)
+        if match and self.source_reference_type == "git":
+            raise ValueError(f"Invalid bundle; git and source cannot both be present\n {content}")
+        elif match:
+            self.source_reference = BundleLinePart("SOURCE", False, match.group(1))
+            self.source_reference_type = "source"
+        
+        if not self.source_reference_type:
+            raise ValueError(f"Invalid bundle; no git or source\n {content}")
+        
+        # Parsing the branch or tag, these are optional (not used by source path) but if
+        # present they are mutually exclusive..
+        match = self._branch_or_tag_re.match(content)
+        if match:
+            self.version_ref_type = match.group(1).lower()
+            self.version_ref = BundleLinePart(match.group(1), False, match.group(2))
+        
+        match = self._remote_rule_re.match(content)
+        if match:
+            self.remote_rule = BundleLinePart(match.group(1), True)
+
+        # Parse both manual and recurive appending each as an attribute.
+        match = self._manual_and_recursive_re.match(content)
+        if match:
+            for m in match.groups():
+                if m:
+                    self.components.append(BundleLinePart(m, True))
+
+    def original_line(self):
+        return self.content
+    
+    def disabled_line(self):
+        return f"# {self.content}"
+    
+    def rewrite_original(self):
+        """Render the original line with the original components; used for testing."""
+        render_components =  [self.project, self.source_reference, self.version_ref, self.remote_rule] + self.components
+        content = " ".join([str(c) for c in render_components])
+        return f"ecbuild_bundle( {content} )"
+
+    def rewrite(self, git_repo: str = None, branch: str = None, tag: str = None):
+        if git_repo:
+            source_reference = BundleLinePart("GIT", False, git_repo, quote_char='"')
+        else:
+            source_reference = self.source_reference
+
+        # Set up local variables from the rewrite parameters.
+        version_ref = None
+        remote_rule = self.remote_rule
+        if branch and tag:
+            raise ValueError("branch and tag cannot both be present")
+        if branch:
+            version_ref = BundleLinePart("BRANCH", False, branch)
+        if tag:
+            version_ref = BundleLinePart("TAG", False, tag)
+            remote_rule = None
+        version_ref = version_ref or self.version_ref
+
+        # Create list of components to render.
+        render_components =  [self.project, source_reference, version_ref]
+        if remote_rule:
+            render_components.append(remote_rule)
+        render_components += self.components
+        content = " ".join([str(c) for c in render_components])
+        return f"ecbuild_bundle( {content} )"
+
+
+class CMakeFile:
+
+    # Ecbuild bundle identfying regex; determines if a line has
+    # an ecbuild_bundle() call that is active (excludes comments).
+    _ecbuild_bundle_re = re.compile(r"\s*ecbuild_bundle\s*\(.*")
+
+    def __init__(self, original_content: str):
+        lines = original_content.splitlines()
+        self.lines = []
+        self.bundle_lines = {}
+        self.bundle_line_names = {}
+        for i, line in enumerate(lines):
+            self.lines.append(line)
+            if self._ecbuild_bundle_re.match(line):
+                bundle_line = BundleLine(line)
+                self.bundle_lines[i] = bundle_line  
+                self.bundle_line_names[bundle_line.project_name] = bundle_line
+
+    def get_github_urls(self):
+        url_map = {}
+        for bundle_name, bundle_line in self.bundle_line_names.items():
+            if bundle_line.source_reference_type == "git" and 'github.com' in bundle_line.source_reference.value:
+                url_map[bundle_name] = bundle_line.source_reference.value
+        return url_map
+
+    def _rewrite_file_implementation(
+            self,
+            file_object,
+            enabled_bundles: Optional[Container[str]] = None,
+            rewrite_rules: Optional[dict[str, str]] = None,
+            build_group_commit_map: Optional[Dict[str, Dict[str, Any]]] = None,
+            ):
+        """Rewrite the CMakeFile object to the file_object.
+
+        Args:
+            file_object: The file to write to.
+            enabled_bundles: A container of bundle names to enable.
+            rewrite_rules: A mapping of bundle names to tags.
+            build_group_commit_map: A mapping of "org/repo" keys to build group commit info.
+                The build group commit info is a dictionary with the following structure:
+                {
+                    "name_key": "org/repo",
+                    "uri": "https://github.com/org/repo.git",
+                    "version_ref": {
+                        "pr_id": 123,
+                        "branch": "feature-branch",
+                        "commit": "abcdef123456"
+                    }
+                }
+        """
+        if enabled_bundles is None:
+            enabled_bundles = set()
+        if rewrite_rules is None:
+            rewrite_rules = {}
+        if build_group_commit_map is None:
+            build_group_commit_map = {}
+
+        # Ensure rewrite_rules and build_group_commit_map are mutually exclusive
+        if rewrite_rules and build_group_commit_map:
+            raise ValueError("rewrite_rules and build_group_commit_map cannot both be provided")
+
+        lines = []
+        for i, line in enumerate(self.lines):
+            # Each line that is not a bundle is left unchanged.
+            if i not in self.bundle_lines:
+                lines.append(line + '\n')
+                continue
+
+            bundle_line = self.bundle_lines[i]
+            # If the line is a bundle we need to determine if/how it should be rewritten.
+            if bundle_line.project_name not in enabled_bundles:
+                lines.append(bundle_line.disabled_line() + '\n')
+                continue
+
+            # Check if this bundle matches a github org/repo key in the build group commit map
+            if bundle_line.github_org_repo_key and bundle_line.github_org_repo_key in build_group_commit_map:
+                # Use the commit hash as a tag
+                commit_info = build_group_commit_map[bundle_line.github_org_repo_key]
+                commit_hash = commit_info["version_ref"]["commit"]
+                lines.append(bundle_line.rewrite(tag=commit_hash) + '\n')
+                continue
+
+            # If the line has a rewrite rule, use it.
+            if bundle_line.project_name in rewrite_rules:
+                tag = rewrite_rules[bundle_line.project_name]
+                lines.append(bundle_line.rewrite(tag=tag) + '\n')
+                continue
+
+            # Finally if the line is enabled and has no rewrite, use the original line.
+            lines.append(bundle_line.original_line() + '\n')
+        
+        # Write the lines to the file.
+        file_object.writelines(lines)
+
+    def basic_rewrite(self, file_object):
+        """Rewrite the CMakeFile object to the file_object."""
+        enabled_bundles = set(self.bundle_line_names.keys())
+        self._rewrite_file_implementation(file_object, enabled_bundles=enabled_bundles)
+
+    def rewrite_whitelist(self,
+                          file_object,
+                          enabled_bundles: Container[str],
+                          rewrite_rules: dict[str, str]):
+        """Rewrite the CMakeFile object to the file_object."""
+        self._rewrite_file_implementation(file_object, enabled_bundles, rewrite_rules)
+
+    def rewrite_blacklist(self,
+                          file_object,
+                          disabled_bundles: Container[str],
+                          rewrite_rules: dict[str, str]):
+        """Rewrite the CMakeFile object to the file_object."""
+        enabled_bundles = set(self.bundle_line_names.keys())
+        for bundle in disabled_bundles:
+            enabled_bundles.discard(bundle)
+        self._rewrite_file_implementation(file_object, enabled_bundles, rewrite_rules)
+
+    def rewrite_build_group_whitelist(self,
+                                      file_object,
+                                      enabled_bundles: Container[str],
+                                      build_group_commit_map: Dict[str, Dict[str, Any]]):
+        """Rewrite the CMakeFile object to the file_object."""
+        self._rewrite_file_implementation(file_object, enabled_bundles, build_group_commit_map=build_group_commit_map)
+
+    def rewrite_build_group_blacklist(self,
+                                      file_object,
+                                      disabled_bundles: Container[str],
+                                      build_group_commit_map: Dict[str, Dict[str, Any]]):
+        """Rewrite the CMakeFile object to the file_object."""
+        enabled_bundles = set(self.bundle_line_names.keys())
+        for bundle in disabled_bundles:
+            enabled_bundles.discard(bundle)
+        self._rewrite_file_implementation(file_object, enabled_bundles, build_group_commit_map=build_group_commit_map)

--- a/ci_action/library/github_client.py
+++ b/ci_action/library/github_client.py
@@ -30,7 +30,7 @@ import os
 import random
 import time
 
-from library import aws_client
+from ci_action.library import aws_client
 
 
 # The init_from_environment() acts as a singleton instantiator to reduce
@@ -38,6 +38,7 @@ from library import aws_client
 # object will be kept here.
 _GITHUB_ENVIRONMENT_CLIENT = None
 
+GITHUB_URI = "https://github.com/"
 
 class GitHubAppClientManager(object):
     """A wrapper for the GitHub client that efficiently uses app credentials.
@@ -175,3 +176,19 @@ def create_check_runs(build_environment, repo, owner, trigger_commit, next_suffi
     integration_run = github_app.create_check_run(
         repo, owner, trigger_commit, integration_run_name)
     return {'unit': unit_run.id, 'integration': integration_run.id}
+
+
+def get_fullname_from_github_uri(repo_uri: str) -> str:
+    """Converts https://github.com/org/repo.git or https://github.com/org/repo into org/repo."""
+    # Remove the GitHub URI prefix
+    repo_path = repo_uri[len(GITHUB_URI):]
+    # Remove .git suffix if present
+    if repo_path.endswith('.git'):
+        repo_path = repo_path[:-4]
+    return repo_path
+
+def get_repo_tuple_from_github_uri(repo_uri: str) -> str:
+    """Converts https://github.com/org/repo.git into a ("repo", "org") tuple."""
+    full_repo = get_fullname_from_github_uri(repo_uri)
+    org, repo = full_repo.split('/', 1)
+    return repo, org

--- a/ci_action/main.py
+++ b/ci_action/main.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import sys
+import subprocess
+import logging
+import pathlib
+import argparse
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+)
+LOG = logging.getLogger("entrypoint")
+
+def check_output(args, **kwargs):
+    """
+    Wrapper around subprocess.check_output that logs the command and its output.
+    """
+    LOG.info(f"Running command: {' '.join(args)}")
+    return subprocess.check_output(args, **kwargs)
+
+def setup_git_credentials(github_token):
+    """
+    Setup Git credentials using the JEDI_CI_TOKEN environment variable.
+    Configures git credential store and writes credentials to file.
+    """
+    # No exception handling here, workflow must fail if this step fails.
+    if github_token:
+        LOG.info("JEDI_CI_TOKEN is set. Setting up Git credentials.")
+
+        # Configure git to use the credential store
+        result = check_output(
+            ["git", "config", "--global", "credential.helper", "store"],
+        )
+        # Write the ~/.git-credentials file
+        credentials_file = pathlib.Path.home() / ".git-credentials"
+        with open(credentials_file, 'w') as f:
+            f.write(f"https://x-access-token:{github_token}@github.com")
+        credentials_file.chmod(0o600)
+        LOG.info(f"Git credentials written to {credentials_file}")
+
+    else:
+        LOG.info("GITHUB_TOKEN is not set. Git operations may require authentication.")
+
+
+def main():
+    """This function is the entrypoint for the CI action, it gets all configuration
+    information and then calls the prepare_and_launch_ci_test function.
+    """
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(description='JEDI CI Action')
+    parser.add_argument('--noop', action='store_true', default=False,
+                       help='No-op mode - exit immediately if set')
+    # DO NOT SUBMIT: this must default to False before submission.
+    parser.add_argument('--environment_query', action='store_true', default=False,
+                       help='Similar to --noop, but will show the environment config')
+    args = parser.parse_args()
+
+    if args.noop:
+        LOG.info("No-op flag set, exiting successfully")
+        return 0
+
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main()) 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "ci_action"
+version = "0.1.0"
+description = "JEDI CI ci_action utilities"
+authors = [
+    { name = "JCSDA", email = "info@jcsda.org" }
+]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "PyGithub",
+    "requests",
+    "pyjwt",
+    "cryptography",
+    "PyGithub>=1.58",
+    "boto3>=1.26",
+    "pyyaml>=6"
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=6.0"
+]
+
+[tool.setuptools]
+packages = ["ci_action", "ci_action.library"]
+package-dir = {"" = "."}
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra -q"
+testpaths = ["test"]
+
+[project.scripts]
+jedi_ci = "ci_action:main"

--- a/test/test_cmake_rewrite.py
+++ b/test/test_cmake_rewrite.py
@@ -1,0 +1,279 @@
+import unittest
+from io import StringIO
+from ci_action.library.cmake_rewrite import BundleLine, CMakeFile
+
+# Example bundle lines for testing
+SIMPLE_GIT_BUNDLE_LINE = 'ecbuild_bundle( PROJECT myproject GIT "https://github.com/myorg/MyRepo.git" BRANCH mybranch UPDATE RECURSIVE )'
+SIMPLE_TAG_LINE = 'ecbuild_bundle( PROJECT myproject GIT "https://github.com/myorg/MyRepo.git" TAG v1.2.3 )'
+TYPICAL_GIT_BUNDLE_LINE = 'ecbuild_bundle( PROJECT oops     GIT "https://github.com/jcsda-internal/oops.git"        BRANCH develop UPDATE )'
+
+class TestBundleLine(unittest.TestCase):
+
+    def test_oops_rewrite_original(self):
+        in_line = TYPICAL_GIT_BUNDLE_LINE
+        # Rewriting a line removes the extra formatting whitespace.
+        want_line = 'ecbuild_bundle( PROJECT oops GIT "https://github.com/jcsda-internal/oops.git" BRANCH develop UPDATE )'
+        bl = BundleLine(in_line)
+        got_line = bl.rewrite_original()
+        self.assertEqual(got_line, want_line)
+
+    def test_oops_rewrite_as_git_commit_hash(self):
+        # Note that "UPDATE" is an attribute only used with branches, for a tag it will be
+        # removed when rewriting to a tag line.
+        in_line = 'ecbuild_bundle( PROJECT oops     GIT "https://github.com/jcsda-internal/oops.git"        BRANCH develop UPDATE )'
+        want_line = 'ecbuild_bundle( PROJECT oops GIT "https://github.com/jcsda-internal/oops.git" TAG 174cf5175ba0e7d256d243d301e0510dd94e23de )'
+        bl = BundleLine(in_line)
+        got_line = bl.rewrite(tag='174cf5175ba0e7d256d243d301e0510dd94e23de')
+        self.assertEqual(got_line, want_line)
+
+    def test_bundle_line_original_line(self):
+        bl = BundleLine(SIMPLE_GIT_BUNDLE_LINE)
+        self.assertEqual(bl.original_line(), SIMPLE_GIT_BUNDLE_LINE)
+
+    def test_parse_git_bundle_line(self):
+        bl = BundleLine(SIMPLE_GIT_BUNDLE_LINE)
+        self.assertEqual(bl.project.value, 'myproject')
+        self.assertEqual(bl.source_reference.value, 'https://github.com/myorg/MyRepo.git')
+        self.assertEqual(bl.source_reference_type, 'git')
+        self.assertEqual(bl.version_ref_type, 'branch')
+
+    def test_parse_tag_bundle_line(self):
+        bl = BundleLine(SIMPLE_TAG_LINE)
+        self.assertEqual(bl.project.value, 'myproject')
+        self.assertEqual(bl.source_reference.value, 'https://github.com/myorg/MyRepo.git')
+        self.assertEqual(bl.source_reference_type, 'git')
+        self.assertEqual(bl.version_ref_type, 'tag')
+        # Org/repo key is derived from the git URI and is lowercased.
+        self.assertEqual(bl.github_org_repo_key, 'myorg/myrepo')
+
+    def test_parse_source_bundle_line(self):
+        source_line = 'ecbuild_bundle( PROJECT myproject SOURCE /path/to/source )'
+        bl = BundleLine(source_line)
+        self.assertEqual(bl.project.value, 'myproject')
+        self.assertEqual(bl.source_reference.value, '/path/to/source')
+        self.assertEqual(bl.source_reference_type, 'source')
+
+    def test_regenerate_original_line(self):
+        bl = BundleLine(SIMPLE_GIT_BUNDLE_LINE)
+        regen = bl.rewrite_original()
+        self.assertIn('ecbuild_bundle(', regen)
+        self.assertIn('PROJECT myproject', regen)
+        self.assertIn('GIT "https://github.com/myorg/MyRepo.git"', regen)
+        self.assertTrue('BRANCH mybranch' in regen or 'TAG' not in regen)
+
+    def test_rewrite_with_new_branch(self):
+        bl = BundleLine(SIMPLE_GIT_BUNDLE_LINE)
+        new_line = bl.rewrite(branch='newbranch')
+        self.assertIn('BRANCH newbranch', new_line)
+        self.assertNotIn('TAG', new_line)
+
+    def test_rewrite_with_new_tag(self):
+        bl = BundleLine(SIMPLE_GIT_BUNDLE_LINE)
+        new_line = bl.rewrite(tag='v2.0.0')
+        self.assertIn('TAG v2.0.0', new_line)
+        self.assertTrue('BRANCH' not in new_line or 'BRANCH mybranch' not in new_line)
+
+    def test_rewrite_with_new_git_repo(self):
+        bl = BundleLine(SIMPLE_GIT_BUNDLE_LINE)
+        new_repo = 'https://github.com/otherorg/otherrepo.git'
+        new_line = bl.rewrite(git_repo=new_repo)
+        self.assertIn(f'GIT "{new_repo}"', new_line)
+        self.assertTrue('myrepo.git' not in new_line or new_repo in new_line)
+
+
+ORIGINAL_CMAKE_FILE = """
+cmake_minimum_required( VERSION 3.14 FATAL_ERROR )
+
+project( jedi-bundle VERSION 8.0.0 LANGUAGES C CXX Fortran )
+
+# Commented out bundle - should not be touched.
+#ecbuild_bundle( PROJECT eckit    GIT "https://github.com/ecmwf/eckit.git" TAG 1.24.4 )
+# Tag Bundle - will be disabled.
+ecbuild_bundle( PROJECT gsibec   GIT "https://github.com/geos-esm/GSIbec" TAG 1.2.1 )
+# Simple Git Bundle - will be updated to a tag.
+ecbuild_bundle( PROJECT oops     GIT "https://github.com/jcsda-internal/oops.git"       BRANCH develop UPDATE )
+# Flag enabled bundle (also whitespace padded bundle).
+if(BUILD_RTTOV)
+  ecbuild_bundle( PROJECT rttov    GIT "https://github.com/jcsda-internal/rttov.git" BRANCH develop UPDATE )
+endif()
+# Recursive Bundle - will also be updated to tag
+ecbuild_bundle( PROJECT pyiri-jedi  GIT     "https://github.com/jcsda-internal/pyiri-jedi.git"    BRANCH develop  UPDATE  RECURSIVE )
+
+ecbuild_bundle_finalize()
+
+"""
+
+TEST_RESULT_CMAKE_FILE = """
+cmake_minimum_required( VERSION 3.14 FATAL_ERROR )
+
+project( jedi-bundle VERSION 8.0.0 LANGUAGES C CXX Fortran )
+
+# Commented out bundle - should not be touched.
+#ecbuild_bundle( PROJECT eckit    GIT "https://github.com/ecmwf/eckit.git" TAG 1.24.4 )
+# Tag Bundle - will be disabled.
+# ecbuild_bundle( PROJECT gsibec   GIT "https://github.com/geos-esm/GSIbec" TAG 1.2.1 )
+# Simple Git Bundle - will be updated to a tag.
+ecbuild_bundle( PROJECT oops GIT "https://github.com/jcsda-internal/oops.git" TAG abc123 )
+# Flag enabled bundle (also whitespace padded bundle).
+if(BUILD_RTTOV)
+  ecbuild_bundle( PROJECT rttov    GIT "https://github.com/jcsda-internal/rttov.git" BRANCH develop UPDATE )
+endif()
+# Recursive Bundle - will also be updated to tag
+ecbuild_bundle( PROJECT pyiri-jedi GIT "https://github.com/jcsda-internal/pyiri-jedi.git" TAG 1337h4x0r RECURSIVE )
+
+ecbuild_bundle_finalize()
+
+"""
+
+
+class TestCMakeFile(unittest.TestCase):
+
+    def test_full_fidelity_rewrite(self):
+        cmake_file = CMakeFile(ORIGINAL_CMAKE_FILE)
+        fake_file = StringIO()
+        cmake_file.basic_rewrite(fake_file)
+        self.maxDiff = None
+        written_text = fake_file.getvalue()
+        print(written_text)
+        self.assertMultiLineEqual(written_text, ORIGINAL_CMAKE_FILE)
+    
+    def test_rewrite_file_simple_tag(self):
+        cmake_file = CMakeFile('# File header\necbuild_bundle( PROJECT oops     GIT "https://github.com/jcsda-internal/oops.git"       BRANCH develop UPDATE )\n')
+        expected = '# File header\necbuild_bundle( PROJECT oops GIT "https://github.com/jcsda-internal/oops.git" TAG abc123 )\n'
+        fake_file = StringIO()
+        cmake_file.rewrite_whitelist(fake_file,
+                                     enabled_bundles=set(['oops']),
+                                     rewrite_rules={'oops': 'abc123'})
+        found_bundle_line = cmake_file.bundle_line_names['oops']
+        self.assertIsInstance(found_bundle_line, BundleLine)
+        self.assertEqual(found_bundle_line.project_name, 'oops')
+        self.assertMultiLineEqual(fake_file.getvalue(), expected)
+    
+    def test_rewrite_build_group_whitelist(self):
+        cmake_file = CMakeFile('# File header\necbuild_bundle( PROJECT oops     GIT "https://github.com/jcsda-internal/oops.git"       BRANCH develop UPDATE )\n')
+        expected = '# File header\necbuild_bundle( PROJECT oops GIT "https://github.com/jcsda-internal/oops.git" TAG abcdef123456 )\n'
+        fake_file = StringIO()
+
+        # Create a build group commit map with the jcsda-internal/oops repository
+        build_group_map = {
+            'jcsda-internal/oops': {
+                'name_key': 'jcsda-internal/oops',
+                'uri': 'https://github.com/jcsda-internal/oops.git',
+                'version_ref': {
+                    'pr_id': 123,
+                    'branch': 'feature-branch',
+                    'commit': 'abcdef123456'
+                }
+            }
+        }
+
+        cmake_file.rewrite_build_group_whitelist(
+            file_object=fake_file,
+            enabled_bundles=set(['oops']),
+            build_group_commit_map=build_group_map
+        )
+
+        found_bundle_line = cmake_file.bundle_line_names['oops']
+        self.assertIsInstance(found_bundle_line, BundleLine)
+        self.assertEqual(found_bundle_line.project_name, 'oops')
+        self.assertEqual(found_bundle_line.github_org_repo_key, 'jcsda-internal/oops')
+        self.assertMultiLineEqual(fake_file.getvalue(), expected)
+
+    def test_rewrite_build_group_whitelist_multiple(self):
+        cmake_file = CMakeFile('# File header\necbuild_bundle( PROJECT oops     GIT "https://github.com/jcsda-internal/oops.git"       BRANCH develop UPDATE )\necbuild_bundle( PROJECT pyiri-jedi  GIT     "https://github.com/jcsda-internal/pyiri-jedi.git"    BRANCH develop  UPDATE  RECURSIVE )\necbuild_bundle( PROJECT gsibec   GIT "https://github.com/geos-esm/GSIbec" TAG 1.2.1 )\n')
+        expected = '# File header\necbuild_bundle( PROJECT oops GIT "https://github.com/jcsda-internal/oops.git" TAG abc123456 )\necbuild_bundle( PROJECT pyiri-jedi GIT "https://github.com/jcsda-internal/pyiri-jedi.git" TAG fedcba654321 RECURSIVE )\n# ecbuild_bundle( PROJECT gsibec   GIT "https://github.com/geos-esm/GSIbec" TAG 1.2.1 )\n'
+        fake_file = StringIO()
+
+        # Create a build group commit map with multiple repositories
+        build_group_map = {
+            'jcsda-internal/oops': {
+                'name_key': 'jcsda-internal/oops',
+                'uri': 'https://github.com/jcsda-internal/oops.git',
+                'version_ref': {
+                    'pr_id': 123,
+                    'branch': 'feature-branch',
+                    'commit': 'abc123456'
+                }
+            },
+            'jcsda-internal/pyiri-jedi': {
+                'name_key': 'jcsda-internal/pyiri-jedi',
+                'uri': 'https://github.com/jcsda-internal/pyiri-jedi.git',
+                'version_ref': {
+                    'pr_id': 456,
+                    'branch': 'feature-branch',
+                    'commit': 'fedcba654321'
+                }
+            }
+        }
+
+        cmake_file.rewrite_build_group_whitelist(
+            file_object=fake_file,
+            enabled_bundles=set(['oops', 'pyiri-jedi']),
+            build_group_commit_map=build_group_map
+        )
+        self.assertMultiLineEqual(fake_file.getvalue(), expected)
+
+    def test_rewrite_build_group_blacklist(self):
+        """This test disables oops and updates pyiri-jedi to a new tag."""
+        cmake_file = CMakeFile('# File header\necbuild_bundle( PROJECT oops     GIT "https://github.com/jcsda-internal/oops.git"  BRANCH develop UPDATE )\necbuild_bundle( PROJECT pyiri-jedi  GIT     "https://github.com/jcsda-internal/pyiri-jedi.git"    BRANCH develop  UPDATE  RECURSIVE )\n')
+        expected = '# File header\n# ecbuild_bundle( PROJECT oops     GIT "https://github.com/jcsda-internal/oops.git"  BRANCH develop UPDATE )\necbuild_bundle( PROJECT pyiri-jedi GIT "https://github.com/jcsda-internal/pyiri-jedi.git" TAG c0ffeec0de RECURSIVE )\n'
+        fake_file = StringIO()
+
+        # Create a build group commit map with the jcsda-internal/pyiri-jedi repository
+        build_group_map = {
+            'jcsda-internal/pyiri-jedi': {
+                'name_key': 'jcsda-internal/pyiri-jedi',
+                'uri': 'https://github.com/jcsda-internal/pyiri-jedi.git',
+                'version_ref': {
+                    'pr_id': 456,
+                    'branch': 'feature-branch',
+                    'commit': 'c0ffeec0de'
+                }
+            }
+        }
+
+        cmake_file.rewrite_build_group_blacklist(
+            file_object=fake_file,
+            disabled_bundles=set(['oops']),
+            build_group_commit_map=build_group_map
+        )
+
+        self.assertMultiLineEqual(fake_file.getvalue(), expected)
+
+    def test_rewrite_file_simple_disable(self):
+        cmake_file = CMakeFile('# File header\necbuild_bundle( PROJECT oops GIT "https://github.com/jcsda-internal/oops.git" BRANCH develop UPDATE )\n')
+        expected = '# File header\n# ecbuild_bundle( PROJECT oops GIT "https://github.com/jcsda-internal/oops.git" BRANCH develop UPDATE )\n'
+        fake_file = StringIO()
+        cmake_file.rewrite_whitelist(fake_file,
+                                     enabled_bundles=set(),
+                                     rewrite_rules={})
+        found_bundle_line = cmake_file.bundle_line_names['oops']
+        self.assertIsInstance(found_bundle_line, BundleLine)
+        self.assertEqual(found_bundle_line.project_name, 'oops')
+        self.assertMultiLineEqual(fake_file.getvalue(), expected)
+        
+
+    def test_rewrite_file(self):
+        cmake_file = CMakeFile(ORIGINAL_CMAKE_FILE)
+        fake_file = StringIO()
+        cmake_file.rewrite_whitelist(fake_file,
+                                     enabled_bundles=set(['oops', 'rttov', 'pyiri-jedi']),
+                                     rewrite_rules={'oops': 'abc123', 'pyiri-jedi': '1337h4x0r'})
+        self.maxDiff = None
+        written_text = fake_file.getvalue()
+        self.assertMultiLineEqual(written_text, TEST_RESULT_CMAKE_FILE)
+    
+    def test_get_github_urls(self):
+        cmake_file = CMakeFile(ORIGINAL_CMAKE_FILE)
+        urls = cmake_file.get_github_urls()
+        expected = {
+            'gsibec': 'https://github.com/geos-esm/GSIbec',
+            'oops': 'https://github.com/jcsda-internal/oops.git',
+            'rttov': 'https://github.com/jcsda-internal/rttov.git',
+            'pyiri-jedi': 'https://github.com/jcsda-internal/pyiri-jedi.git'
+        }
+        self.assertDictEqual(urls, expected)
+
+
+if __name__ == '__main__':
+    unittest.main() 


### PR DESCRIPTION
This is the first in a series of PRs that will be necessary to get the updated testing system submitted. This specific change is the first of 3 substantial component rewrites. I've simplified the system used to rewrite our cmake files which had grown organically into an unmaintainable mess. This rewrite is moderately better although retains some of the structure of the original. I did not include a diff (unlike other components) since very little of the original code is retained.

The module `cmake_rewrite.py` allows the loading of a "CMakeLists.txt" file and subsequent rewriting of that file following various substitution rules including disabling of bundle lines or substitution of branches for tags.

### Other included changes.

* Add the pyproject.toml
* Add the basic skeleton of the "main.py" function used as the entrypoint.
* Add tests and test running config (using pytest)
* Some small changes to other files as necessary for `cmake_rewrite.py`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have run the unit tests before creating the PR
