### PR TITLE
Deprecate old annotations.

### DIFF
--- a/ci_action/implementation.py
+++ b/ci_action/implementation.py
@@ -108,11 +108,11 @@ def prepare_and_launch_ci_test(
 
     # Check draft PR run status.
     if config.get('pr_payload', {}).get('draft') and not test_annotations.run_on_draft:
-        print('Tests are not launched for draft PRs by default.')
-        print('To enable testing on draft PRs, add the following annotation to the PR:')
-        print('```')
-        print('run-ci-on-draft = true')
-        print('```')
+        LOG.info('\n\nTests are not launched for draft PRs by default.\n'
+                 'To enable testing on draft PRs, add the following annotation to the PR:\n'
+                 '```\n'
+                 'run-ci-on-draft = true\n'
+                 '```\n')
         return blocking_errors, non_blocking_errors
 
     bundle_branch = config['bundle_branch']  # This is the default branch to use for the bundle.

--- a/ci_action/implementation.py
+++ b/ci_action/implementation.py
@@ -101,8 +101,10 @@ def prepare_and_launch_ci_test(
         return blocking_errors, non_blocking_errors
 
     LOG.info('test_annotations:')
-    annotations_pretty = pprint.pformat(test_annotations)
+    annotations_pretty = pprint.pformat(test_annotations._asdict())
     LOG.info(f'{timer.checkpoint()}\n{annotations_pretty}')
+    LOG.info(f'Pull request is draft? {repr(config.get("pr_payload", {}).get("draft"))}')
+
 
     # Check draft PR run status.
     if config.get('pr_payload', {}).get('draft') and not test_annotations.run_on_draft:

--- a/ci_action/implementation.py
+++ b/ci_action/implementation.py
@@ -71,29 +71,47 @@ def prepare_and_launch_ci_test(
         target_repo_path: The path to the target repository.
 
     Returns:
-        A list of errors that occurred during the test launch. Any potentially
-        recoverable errors should be returned as a list of strings so that the
-        action can fail (notifying us of an issue) even if part of the test
-        launches successfully.
+        A 2-tuple of lists of strings representing errors:
+        - blocking_errors: Errors that preventing the tests from launching.
+        - non_blocking_errors Any potentially recoverable errors that may
+            have occurred during the test launch but did not prevent the test
+            jobs from launching. These errors will be logged as non-blocking
     """
     # Some cleanup and housekeeping operations should not block the test launch
     # but should be logged as non-blocking errors so the action can fail (notifying
     # us of an issue).
     non_blocking_errors = []
+    # Errors that prevent the tests from launching (e.g. misconfigured test annotations
+    # or pr groups that don't exist).
+    blocking_errors = []
 
     timer = TimeCheckpointer()  # Timer for logging.
 
     # Fetch config from the pull request data
     repo_uri = f'https://github.com/{config["owner"]}/{config["repo_name"]}.git'
-    test_annotations = pr_resolve.read_test_annotations(
-        repo_uri=repo_uri,
-        pr_number=config['pull_request_number'],
-        pr_payload=config['pr_payload'],
-        testmode=config['self_test'],
-    )
+    try:
+        test_annotations = pr_resolve.read_test_annotations(
+            repo_uri=repo_uri,
+            pr_number=config['pull_request_number'],
+            pr_payload=config['pr_payload'],
+            testmode=config['self_test'],
+        )
+    except pr_resolve.Exception as e:
+        blocking_errors.append(f"Error reading test annotations: {e}")
+        return blocking_errors, non_blocking_errors
+
     LOG.info('test_annotations:')
     annotations_pretty = pprint.pformat(test_annotations)
     LOG.info(f'{timer.checkpoint()}\n{annotations_pretty}')
+
+    # Check draft PR run status.
+    if config.get('pr_payload', {}).get('draft') and not test_annotations.run_on_draft:
+        print('Tests are not launched for draft PRs by default.')
+        print('To enable testing on draft PRs, add the following annotation to the PR:')
+        print('```')
+        print('run-ci-on-draft = true')
+        print('```')
+        return blocking_errors, non_blocking_errors
 
     bundle_branch = config['bundle_branch']  # This is the default branch to use for the bundle.
     if test_annotations.jedi_bundle_branch:
@@ -268,4 +286,4 @@ def prepare_and_launch_ci_test(
             f'{timer.checkpoint()}\nSubmitted Batch Job for build environment '
             f'{build_environment}: "{job_arn}".'
         )
-    return non_blocking_errors
+    return blocking_errors, non_blocking_errors

--- a/ci_action/implementation.py
+++ b/ci_action/implementation.py
@@ -103,8 +103,6 @@ def prepare_and_launch_ci_test(
     LOG.info('test_annotations:')
     annotations_pretty = pprint.pformat(test_annotations._asdict())
     LOG.info(f'{timer.checkpoint()}\n{annotations_pretty}')
-    LOG.info(f'Pull request is draft? {repr(config.get("pr_payload", {}).get("draft"))}')
-
 
     # Check draft PR run status.
     if config.get('pr_payload', {}).get('draft') and not test_annotations.run_on_draft:

--- a/ci_action/implementation.py
+++ b/ci_action/implementation.py
@@ -113,7 +113,6 @@ def prepare_and_launch_ci_test(
                  '```\n')
         return blocking_errors, non_blocking_errors
 
-
     bundle_branch = config['bundle_branch']  # This is the default branch to use for the bundle.
     if test_annotations.jedi_bundle_branch:
         bundle_branch = test_annotations.jedi_bundle_branch  # Override based on PR annotations.

--- a/ci_action/implementation.py
+++ b/ci_action/implementation.py
@@ -111,11 +111,8 @@ def prepare_and_launch_ci_test(
                  '```\n'
                  'run-ci-on-draft = true\n'
                  '```\n')
-<<<<<<< HEAD
         return blocking_errors, non_blocking_errors
-=======
-        return non_blocking_errors
->>>>>>> develop
+
 
     bundle_branch = config['bundle_branch']  # This is the default branch to use for the bundle.
     if test_annotations.jedi_bundle_branch:

--- a/ci_action/library/pr_resolve.py
+++ b/ci_action/library/pr_resolve.py
@@ -34,8 +34,13 @@ CI_TEST_SELECT_RE = re.compile(
     r'^jedi-ci-test-select\s?=\s?(random|all|intel|gcc|gcc11)?\s*$', re.MULTILINE | re.IGNORECASE)
 JEDI_BUNDLE_BRANCH_RE = re.compile(
     r'^jedi-ci-bundle-branch\s?=\s?([a-zA-Z0-9\/:#\._-]{1,70})?\s*$', re.MULTILINE | re.IGNORECASE)
-MANIFEST_BRANCH_RE = re.compile(
+DEPRECATED_MANIFEST_BRANCH_RE = re.compile(
     r'^jedi-ci-manifest-branch\s?=\s?([a-zA-Z0-9\/:#\._-]{1,70})?\s*$', re.MULTILINE | re.IGNORECASE)  # noqa: E501
+
+
+class Exception(Exception):
+    """Exception raised by any well-characterized PR resolve failure."""
+    pass
 
 
 class TestAnnotations(NamedTuple):
@@ -48,15 +53,8 @@ class TestAnnotations(NamedTuple):
     # not read from the cache and will build all code.
     skip_cache: str
 
-    # A string value representing a json boolean ("true" or "false"). This is
-    # passed to the build-info json file. If set to "true" the cache will be
-    # re-built.
-    rebuild_cache: str
-
-    # If False, tests will not be run for this change. This setting is used
-    # when evaluating draft pull requests which will not run by default but
-    # may be enabled with an annotation.
-    run_tests: bool
+    # Should draft pull request run all tests. Defaults to False.
+    run_on_draft: bool
 
     # If True, a 2-hour sleep will be added to the conclusion of a test.
     debug_mode: bool
@@ -75,12 +73,6 @@ class TestAnnotations(NamedTuple):
     # default branch. This branch must exist in `JCSDA-internal/jedi-bundle`.
     jedi_bundle_branch: str
 
-    # Set the CI test manifest config file branch used for evaluating the test
-    # dependencies. If this value is not set (or is set to an empty string) the
-    # lambda function will use the 'develop' branch. Any specified branch
-    # must exist in `JCSDA-internal/CI` or the test will fail to configure.
-    jedi_ci_manifest_branch: str
-
 
 def read_test_annotations(
         repo_uri: str,
@@ -94,7 +86,7 @@ def read_test_annotations(
         test_select_regex=CI_TEST_SELECT_RE,
         next_ci_regex=NEXT_CI_RE,
         jedi_bundle_branch_regex=JEDI_BUNDLE_BRANCH_RE,
-        manifest_branch_regex=MANIFEST_BRANCH_RE,
+        manifest_branch_regex=DEPRECATED_MANIFEST_BRANCH_RE,
 ) -> TestAnnotations:
     """Reads all jedi-ci specific behavior annotations from a pull request.
 
@@ -130,32 +122,22 @@ def read_test_annotations(
         repo_name, org = github_client.get_repo_tuple_from_github_uri(repo_uri=repo_uri)
         build_group_pr_map[f'{org.lower()}/{repo_name.lower()}'] = int(pr_number)
 
-    # Cache behavior: note that skip cache controls read behavior while
-    # rebuild_cache controls write behavior. The correct global behavior can
-    # be understood globally from the keyword used since rebuilding the cache
-    # requires also skipping cache lookup a user skipping the cache may not
-    # want their change to update the shared binary cache.
+    # Cache behavior: "rebuild" is no longer supported. Only 'skip'.
+    skip_cache = 'false'
     cache_behavior = cache_regex.findall(pr_body)
+    if cache_behavior and cache_behavior[0].lower() == 'rebuild':
+        raise Exception('Cache rebuild (annotation "jedi-ci-build-cache=rebuild")'
+                        ' is no longer supported.')
     if cache_behavior and cache_behavior[0].lower() == 'skip':
         skip_cache = 'true'
-        rebuild_cache = 'false'
-    elif cache_behavior and cache_behavior[0].lower() == 'rebuild':
-        skip_cache = 'true'
-        rebuild_cache = 'true'
-    else:
-        skip_cache = 'false'
-        rebuild_cache = 'false'
+
     # Draft pull requests must be annotated for tests to run. If a pull request
     # is a draft pull request, the tests will be skipped unless the author
     # has added an annotation.
-    run_tests = False  # Start with negative assumption.
-    if not pr_payload.get('draft'):
-        run_tests = True  # Run tests if pr is not a draft.
-    else:
-        # Run tests if PR is a draft and annotated to run anyways.
-        draft_pr_note = draft_regex.findall(pr_body)
-        if draft_pr_note and draft_pr_note[0].lower() in ['t', 'true', 'yes']:
-            run_tests = True
+    run_on_draft = False  # Start with negative assumption.
+    draft_pr_note = draft_regex.findall(pr_body)
+    if draft_pr_note and draft_pr_note[0].lower() in ['t', 'true', 'yes']:
+        run_on_draft = True
 
     # Check if debug mode is enabled.
     debug_mode = bool(debug_regex.findall(pr_body))
@@ -169,36 +151,27 @@ def read_test_annotations(
     else:
         test_select = 'random'
 
-    # Determine if there is a nonstandard jedi-bundle branch. Finding any
-    # value here updates the cache behavior to skip since the bundle changes
-    # may alter the build dependency DAG.
+    # Determine if there is a nonstandard jedi-bundle branch.
     bundle_branch_config = jedi_bundle_branch_regex.findall(pr_body)
     bundle_branch = ''
     if bundle_branch_config:
         bundle_branch = bundle_branch_config[0]
-        skip_cache = 'true'  # Do not read from the cache.
-        rebuild_cache = 'false'  # Do not save build results to the cache.
 
-    # If an alternative manifest branch is set, fetch it. Finding any value
-    # here updates the cache behavior to skip since the manifest may contain
-    # conflicting cache directives.
+    # There is no longer a unified "manifest". This check raises an exception
+    # so that the user re-configures their test annotations.
     manifest_branch_config = manifest_branch_regex.findall(pr_body)
-    manifest_branch = ''
     if manifest_branch_config:
-        manifest_branch = manifest_branch_config[0]
-        skip_cache = 'true'  # Do not read from the cache.
-        rebuild_cache = 'false'  # Do not save build results to the cache.
+        raise Exception('The "jedi-ci-manifest-branch" annotation is deprecated; dependency'
+                        ' configuration is now in //.github/workflows/start-jedi-ci.yml')
 
     return TestAnnotations(
         build_group_map=build_group_pr_map,
         skip_cache=skip_cache,
-        rebuild_cache=rebuild_cache,
-        run_tests=run_tests,
+        run_on_draft=run_on_draft,
         debug_mode=debug_mode,
         next_ci_suffix=next_ci_suffix,
         test_select=test_select,
         jedi_bundle_branch=bundle_branch,
-        jedi_ci_manifest_branch=manifest_branch,
     )
 
 

--- a/ci_action/main.py
+++ b/ci_action/main.py
@@ -155,7 +155,7 @@ def main():
     setup_git_credentials(os.environ.get('JEDI_CI_TOKEN'))
 
     # Prepare and launch the CI test
-    errors = ci_implementation.prepare_and_launch_ci_test(
+    errors, non_blocking_errors = ci_implementation.prepare_and_launch_ci_test(
         infra_config=JEDI_CI_INFRA_CONFIG,
         config=env_config,
         bundle_repo_path=os.path.join(workspace_dir, 'bundle'),
@@ -164,6 +164,14 @@ def main():
     if errors:
         # Enumerate and indent each error message.
         indented_errors = [textwrap.indent(e, '    ') for e in errors]
+        enumerated_errors = [f' {i+1}. ' + e[4:] for i, e in enumerate(indented_errors)]
+        error_list = '\n'.join(enumerated_errors)
+        LOG.error(f"Tests could not launch due to these errors:\n{error_list}")
+        return 1
+
+    if non_blocking_errors:
+        # Enumerate and indent each error message.
+        indented_errors = [textwrap.indent(e, '    ') for e in non_blocking_errors]
         enumerated_errors = [f' {i+1}. ' + e[4:] for i, e in enumerate(indented_errors)]
         error_list = '\n'.join(enumerated_errors)
         LOG.error(f"Tests launched successfully but experienced errors:\n{error_list}")

--- a/ci_action/main.py
+++ b/ci_action/main.py
@@ -12,7 +12,6 @@ import os
 import pathlib
 import subprocess
 import sys
-import textwrap
 
 from ci_action import implementation as ci_implementation
 

--- a/ci_action/main.py
+++ b/ci_action/main.py
@@ -169,18 +169,26 @@ def main():
         bundle_repo_path=os.path.join(workspace_dir, 'bundle'),
         target_repo_path=target_repo_full_path)
 
+    # The following block is used to format a list of errors that will be logged to the GitHub
+    # action log. The output should look something like this.
+    # ...
+    # Tests could not launch due to these errors:
+    #  1. error message number one
+    #  2. error message number two
     if errors:
         # Enumerate and indent each error message.
-        indented_errors = [textwrap.indent(e, '    ') for e in errors]
-        enumerated_errors = [f' {i+1}. ' + e[4:] for i, e in enumerate(indented_errors)]
+        enumerated_errors = [f' {i+1}. ' + str(e) for i, e in enumerate(errors)]
         error_list = '\n'.join(enumerated_errors)
         LOG.error(f"Tests could not launch due to these errors:\n{error_list}")
         return 1
 
+    # Non-blocking errors note internal failures that must be addressed but that did not
+    # prevent the tests from launching. We are still returning a failure code to the GitHub
+    # action so that internal errors are surfaced and addressed. These errors are formatted
+    # like the blocking errors but with a different message noting the succesful test launch.
     if non_blocking_errors:
         # Enumerate and indent each error message.
-        indented_errors = [textwrap.indent(e, '    ') for e in non_blocking_errors]
-        enumerated_errors = [f' {i+1}. ' + e[4:] for i, e in enumerate(indented_errors)]
+        enumerated_errors = [f' {i+1}. ' + str(e) for i, e in enumerate(non_blocking_errors)]
         error_list = '\n'.join(enumerated_errors)
         LOG.error(f"Tests launched successfully but experienced errors:\n{error_list}")
         return 1


### PR DESCRIPTION
### Changes:
 * Some old config options were still being evaluated and are now disabled with an error if used.
    *  `jedi-ci-manifest-branch`: there is no more manifest.
    * `jedi-ci-build-cache=rebuild`: there will be no rebuild option.
 * Internal to the main execution, a new concept of "blocking errors" was added so that certain well-understood failures (like misconfiguration) could be pretty formatted and explained rather than resulting in a stack trace.
 
### Example of this working:
 * Using deprecated annotation: [saber#1092 run 17332264508](https://github.com/JCSDA-internal/saber/actions/runs/17332264508/job/49210781503?pr=1092)
 * "Vanilla" example of action working as intended: [saber#1092 run 17590787215](https://github.com/JCSDA-internal/saber/actions/runs/17590787215/job/49970782159?pr=1092)