### PR TITLE
Fix disk space error bug by adding version ref to ec2 template

### DIFF
--- a/cfn/jedi-ci-action.yaml
+++ b/cfn/jedi-ci-action.yaml
@@ -462,6 +462,7 @@ Resources:
         Type: EC2
         LaunchTemplate:
           LaunchTemplateId: !Ref EC2LaunchTemplate
+          Version: !GetAtt EC2LaunchTemplate.LatestVersionNumber
         # By setting MinvCpus to zero, batch is allowed to tear down all EC2
         # instances that are not in use. If this number is larger than 0, it
         # will maintain at enough instances to meet the minimum. The parameter


### PR DESCRIPTION
The version ref is needed to get the latest version of the template. Once the disk space was moved to a parameter we stopped getting updates because the resource was versioned rather than renewed due to direct edits.

Fixes: https://github.com/JCSDA-internal/CI/issues/155
