### PR TITLE
Fix git credential failures

### DIFF
--- a/shell/git_askPass_app_credentials.py
+++ b/shell/git_askPass_app_credentials.py
@@ -44,7 +44,7 @@ def generate_token(pem_file, app_id, install_id, current_time):
     # relative to local time and set expiration to 20 minutes.
     clock_drift_factor = 10
     issue_time = current_time - clock_drift_factor
-    expiration_time = issue_time + 1200
+    expiration_time = issue_time + 600
 
     payload = {
         'iat': issue_time,

--- a/shell/git_askPass_app_credentials.py
+++ b/shell/git_askPass_app_credentials.py
@@ -40,8 +40,8 @@ def generate_token(pem_file, app_id, install_id, current_time):
     with open(pem_file, 'r') as f:
         key_text = f.read()
     # This is used to make sure that we never issue "future" tokens that will
-    # not be honored by GitHub. Set the issue time as 10 seconds in the past
-    # relative to local time and set expiration to 20 minutes.
+    # not be honored by GitHub. This factor is also subtracted from local
+    # expiration since GitHub allows 10 minutes TTL for auth tokens.
     clock_drift_factor = 10
     issue_time = current_time - clock_drift_factor
     expiration_time = issue_time + 600

--- a/shell/git_askPass_app_credentials.py
+++ b/shell/git_askPass_app_credentials.py
@@ -40,11 +40,11 @@ def generate_token(pem_file, app_id, install_id, current_time):
     with open(pem_file, 'r') as f:
         key_text = f.read()
     # This is used to make sure that we never issue "future" tokens that will
-    # not be honored by GitHub. This factor is also subtracted from local
-    # expiration since GitHub allows 10 minutes TTL for auth tokens. 
+    # not be honored by GitHub. Set the issue time as 10 seconds in the past
+    # relative to local time and set expiration to 20 minutes.
     clock_drift_factor = 10
     issue_time = current_time - clock_drift_factor
-    expiration_time = issue_time + 600
+    expiration_time = issue_time + 1200
 
     payload = {
         'iat': issue_time,

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -214,6 +214,12 @@ echo "-------------------------------------------------------"
 #
 cd "${BUILD_DIR}"
 
+echo "-#--#- start vader debug clone #1 -#--#-"
+pushd /tmp
+GIT_TRACE=1 git clone https://github.com/jcsda-internal/vader.git vader-test1
+popd
+echo "-#--#- done vader debug clone #1 -#--#-"
+
 ecbuild \
       -Wno-dev \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -313,6 +319,11 @@ ecbuild \
       -DBUILD_PYIRI=ON \
       ${COMPILER_FLAGS[@]} "${JEDI_BUNDLE_DIR}"
 if [ $? -ne 0 ]; then
+    echo "-#--#- start vader debug clone #1 -#--#-"
+    pushd /tmp
+    GIT_TRACE=1 git clone https://github.com/jcsda-internal/vader.git vader-test1
+    popd
+    echo "-#--#- done vader debug clone #1 -#--#-"
     util.check_run_fail $TRIGGER_REPO_FULL $INTEGRATION_RUN_ID "ecbuild failed"
     util.evaluate_debug_timer_then_cleanup
     exit 0

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -319,11 +319,11 @@ ecbuild \
       -DBUILD_PYIRI=ON \
       ${COMPILER_FLAGS[@]} "${JEDI_BUNDLE_DIR}"
 if [ $? -ne 0 ]; then
-    echo "-#--#- start vader debug clone #1 -#--#-"
+    echo "-#--#- start vader debug clone #2 -#--#-"
     pushd /tmp
-    GIT_TRACE=1 git clone https://github.com/jcsda-internal/vader.git vader-test1
+    GIT_TRACE=1 git clone https://github.com/jcsda-internal/vader.git vader-test2
     popd
-    echo "-#--#- done vader debug clone #1 -#--#-"
+    echo "-#--#- done vader debug clone #2 -#--#-"
     util.check_run_fail $TRIGGER_REPO_FULL $INTEGRATION_RUN_ID "ecbuild failed"
     util.evaluate_debug_timer_then_cleanup
     exit 0

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -215,12 +215,6 @@ echo "-------------------------------------------------------"
 #
 cd "${BUILD_DIR}"
 
-echo "-#--#- start vader debug clone #1 -#--#-"
-pushd /tmp
-GIT_TRACE=1 git clone https://github.com/jcsda-internal/vader.git vader-test1
-popd
-echo "-#--#- done vader debug clone #1 -#--#-"
-
 ecbuild \
       -Wno-dev \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
@@ -320,11 +314,6 @@ ecbuild \
       -DBUILD_PYIRI=ON \
       ${COMPILER_FLAGS[@]} "${JEDI_BUNDLE_DIR}"
 if [ $? -ne 0 ]; then
-    echo "-#--#- start vader debug clone #2 -#--#-"
-    pushd /tmp
-    GIT_TRACE=1 git clone https://github.com/jcsda-internal/vader.git vader-test2
-    popd
-    echo "-#--#- done vader debug clone #2 -#--#-"
     util.check_run_fail $TRIGGER_REPO_FULL $INTEGRATION_RUN_ID "ecbuild failed"
     util.evaluate_debug_timer_then_cleanup
     exit 0

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -140,7 +140,7 @@ util.check_run_start_build $TRIGGER_REPO_FULL $UNIT_RUN_ID
 # Get all GitLFS repositories from s3.
 pushd ${JEDI_BUNDLE_DIR}
 echo "showing git config"
-git config --global credential.helper 'cache --timeout=1200'
+git config --global credential.helper 'cache --timeout=590'
 git config --list
 echo "Fetching GitLFS repositories via tarball."
 git config --global --add safe.directory '*'

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -140,6 +140,7 @@ util.check_run_start_build $TRIGGER_REPO_FULL $UNIT_RUN_ID
 # Get all GitLFS repositories from s3.
 pushd ${JEDI_BUNDLE_DIR}
 echo "showing git config"
+git config --global credential.helper 'cache --timeout=1200'
 git config --list
 echo "Fetching GitLFS repositories via tarball."
 git config --global --add safe.directory '*'


### PR DESCRIPTION
This fix appears to resolve the recently observed git credential failures during ecbuild.

## Background

I'll start by noting that the following is an educate guess and a lot of the details were hard to verify since they cover the Venn diagram overlap of "poorly documented git features" and "poorly documented git integrations".

I believe that ecbuild is using git in a way that relies on simplified authentication logic; it appears to call credentials in some specific order of preference and will only use whichever credential it gets first. This is unlike typical git invocations from the shell in at least one specific case; if cached credentials are used and return an authentication error, git will attempt to fall back to a lower-preference method such as git `askPass` and this lower preference method will update the cache.

This issue was observed infrequently in the past an never replicated, but recently has become a very consistent cause of failure. I think this is because ecbuild has been taking a little longer lately and whereas it would not run-out the 10-minute token TTL in the past, it now does this most of the time. Because the cache was configured to last longer than the token, the cache would return an invalid token which would cause the failure then ecbuild would report the failure immediately without running any token-refresh logic.

The failure has been observed consistently and this fix worked on its first attempt. As of now my best evidence for the correctness of my theory is that this fix works. If the issue comes up again we might have to revisit.

## Issues

https://github.com/JCSDA-internal/jedi-ci/issues/24

