### PR TITLE
[bugfix] Remove references to build json - fixes oasim tests.

### DIFF
--- a/ci_action/implementation.py
+++ b/ci_action/implementation.py
@@ -279,7 +279,7 @@ def prepare_and_launch_ci_test(
             trigger_pr=str(config['pull_request_number']),
             integration_run_id=checkrun_id_map['integration'],
             unit_run_id=checkrun_id_map['unit'],
-            unittest_dependencies=' '.join(config['unittest_dependencies']),
+            unittest_dependencies=' '.join(enabled_bundles),
             test_script=config['test_script'],
         )
         job_arn = job['jobArn']

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -114,19 +114,8 @@ set -x
 # Setup and run tests.
 #
 
-#REFRESH_CACHE_ON_FETCH="$(jq -r ".skip_cache" $BUILD_JSON)"
-#REFRESH_CACHE_ON_WRITE="$(jq -r ".rebuild_cache" $BUILD_JSON)"
-#JEDI_BUNDLE_BRANCH="$(jq -r ".jedi_bundle_branch" $BUILD_JSON)"
-
 # Extract just the repo name from the full repository path
 TRIGGER_REPO=$(echo "$TRIGGER_REPO_FULL" | cut -d'/' -f2)
-
-
-# Generate the version ref flag value used later for build config. Ignore
-# entries with null version_ref.commit values they are branch references already
-# configured in the bundle.
-UNIT_DEPENDENCIES=$(jq -r '.dependencies | join(" ")' $BUILD_JSON)
-
 
 if [ "${CREATE_CHECK_RUNS}" == "yes" ]; then
     UNIT_RUN_ID=$(util.check_run_new $TRIGGER_REPO_FULL "unit" $TRIGGER_SHA)


### PR DESCRIPTION
This fixes a unittest dependencies glitch that is currently blocking oasim tests from running. In the prior "CI" codebase, unittest dependencies were being passed in by the json config file. Now they are a parameter set by the AWS Batch caller.

Fixes: https://github.com/JCSDA-internal/oasim/pull/8

## Checklist

- [x] I have performed a self-review of my own code
- __n/a__ I have made corresponding changes to the documentation
- [x] I have run the unit tests before creating the PR
