### PR TITLE
Short timeout for soca

### DIFF
--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -346,7 +346,12 @@ TEST_TAG=$(head -1 "${BUILD_DIR}/Testing/TAG")
 util.check_run_start_test $TRIGGER_REPO_FULL $SECOND_CHECK_RUN_ID
 
 # Run integration tests.
-ctest -LE "${UNITTEST_TAG}|gsibec|rttov|oasim|ropp-ufo" --timeout 180 -C RelWithDebInfo -D ExperimentalTest
+TEST_TIMEOUT=180
+# TODO(https://github.com/JCSDA-internal/jedi-ci/issues/37): revert this once we have a permanent fix.
+if [ "${TRIGGER_REPO}" = "soca" ]; then
+    TEST_TIMEOUT=30
+fi
+ctest -LE "${UNITTEST_TAG}|gsibec|rttov|oasim|ropp-ufo" --timeout $TEST_TIMEOUT -C RelWithDebInfo -D ExperimentalTest
 
 # Upload ctests.
 ctest -C RelWithDebInfo -D ExperimentalSubmit -M Continuous -- --track Continuous --group Continuous


### PR DESCRIPTION
This is for debugging soca timeout failures described here https://github.com/JCSDA-internal/jedi-ci/issues/35.

This will be reverted: https://github.com/JCSDA-internal/jedi-ci/issues/37