### PR TITLE
Patch for ukmo build group breaking CI.

### DIFF
--- a/ci_action/library/pr_resolve.py
+++ b/ci_action/library/pr_resolve.py
@@ -179,14 +179,15 @@ def read_test_annotations(
 def get_build_group_pr_map(build_group_members):
     pr_map = {}
     for member in build_group_members:
-        if 'github.com/metoffice' in member.lower():
+        member_match = BUILD_GROUP_LINK.search(member)
+        if not member_match:
+            LOG.info(f'Skipping malformed build group: {member}')
+            continue
+        owner, repo, pull_number = member_match.groups()
+        if owner.lower() == 'metoffice':
             # UKMO CI tests some non-public code which JEDI-CI will skip.
             LOG.info(f'Skipping UKMO build group: {member}')
             continue
-        member_match = BUILD_GROUP_LINK.search(member)
-        if not member_match:
-            continue
-        owner, repo, pull_number = member_match.groups()
         pr_map[f'{owner.lower()}/{repo.lower()}'] = int(pull_number)
     return pr_map
 

--- a/ci_action/library/pr_resolve.py
+++ b/ci_action/library/pr_resolve.py
@@ -179,6 +179,10 @@ def read_test_annotations(
 def get_build_group_pr_map(build_group_members):
     pr_map = {}
     for member in build_group_members:
+        if 'github.com/metoffice' in member.lower():
+            # UKMO CI tests some non-public code which JEDI-CI will skip.
+            LOG.info(f'Skipping UKMO build group: {member}')
+            continue
         member_match = BUILD_GROUP_LINK.search(member)
         if not member_match:
             continue


### PR DESCRIPTION
Fixes the permanent CI failure here: https://github.com/JCSDA-internal/ufo/actions/runs/19147260958/job/54727996368?pr=3857

Shortly, UKMO is using our build-group annotations for some non-public repos. That breaks our launcher when it attempts to query pull request metadata. This quick patch filters out ukmo build groups.