### PR TITLE
Flags for spack-stack 2.0 release support.

### DIFF
--- a/shell/environment.sh
+++ b/shell/environment.sh
@@ -42,19 +42,20 @@ export TEST_ROOT="${WORKDIR}"
 export JEDI_BUNDLE_DIR="${WORKDIR}/bundle"
 export CI_SCRIPTS_DIR=$WORKDIR/bundle/jedi_ci_resources
 export BUILD_PARALLELISM=5
-export ENV_EXCLUDES=""
 
 
 # Set compiler-specific flags and options specific to different tool chains. The
 # COMPILER_FLAGS array is used in the ecbuild invocation.
 export COMPILER_FLAGS=( '-DCMAKE_DISABLE_FIND_PACKAGE_bufr_query=ON' )
+export ENV_CTEST_EXCLUDES=""
+
 if [ $JEDI_COMPILER = "intel" ]; then
     source /opt/intel/oneapi/compiler/latest/env/vars.sh
     source /opt/intel/oneapi/mpi/latest/env/vars.sh
     # Compiling with -O2 is too slow and uses too much memory
     COMPILER_FLAGS+=( '-DECBUILD_C_FLAGS_RELWITHDEBINFO="-O1 -g"' '-DECBUILD_CXX_FLAGS_RELWITHDEBINFO="-O1 -g"' '-DECBUILD_Fortran_FLAGS_RELWITHDEBINFO="-O1 -g -fp-model=precise"' )
     export BUILD_PARALLELISM=4
-    export ENV_EXCLUDES="CI_exclude_hang_gnssro_ukmo_intel_O1|CI_exclude_segfault_camelemis_atlas"
+    export ENV_CTEST_EXCLUDES="CI_exclude_hang_gnssro_ukmo_intel_O1|CI_exclude_segfault_camelemis_atlas"
 fi
 
 if [ $JEDI_COMPILER = "clang" ]; then

--- a/shell/environment.sh
+++ b/shell/environment.sh
@@ -46,12 +46,12 @@ export BUILD_PARALLELISM=5
 
 # Set compiler-specific flags and options specific to different tool chains. The
 # COMPILER_FLAGS array is used in the ecbuild invocation.
-export COMPILER_FLAGS=( )
+export COMPILER_FLAGS=( '-DCMAKE_DISABLE_FIND_PACKAGE_bufr_query=ON' )
 if [ $JEDI_COMPILER = "intel" ]; then
     source /opt/intel/oneapi/compiler/latest/env/vars.sh
     source /opt/intel/oneapi/mpi/latest/env/vars.sh
     # Compiling with -O2 is too slow and uses too much memory
-    export COMPILER_FLAGS=( -DECBUILD_C_FLAGS_RELWITHDEBINFO=-O1 -DECBUILD_CXX_FLAGS_RELWITHDEBINFO=-O1 -DECBUILD_Fortran_FLAGS_RELWITHDEBINFO=-O1 )
+    COMPILER_FLAGS+=( '-DECBUILD_C_FLAGS_RELWITHDEBINFO="-O1 -g"' '-DECBUILD_CXX_FLAGS_RELWITHDEBINFO="-O1 -g"' '-DECBUILD_Fortran_FLAGS_RELWITHDEBINFO="-O1 -g -fp-model=precise"' )
     export BUILD_PARALLELISM=4
 fi
 

--- a/shell/environment.sh
+++ b/shell/environment.sh
@@ -55,7 +55,7 @@ if [ $JEDI_COMPILER = "intel" ]; then
     # Compiling with -O2 is too slow and uses too much memory
     COMPILER_FLAGS+=( '-DECBUILD_C_FLAGS_RELWITHDEBINFO="-O1 -g"' '-DECBUILD_CXX_FLAGS_RELWITHDEBINFO="-O1 -g"' '-DECBUILD_Fortran_FLAGS_RELWITHDEBINFO="-O1 -g -fp-model=precise"' )
     export BUILD_PARALLELISM=4
-    export ENV_CTEST_EXCLUDES="CI_exclude_hang_gnssro_ukmo_intel_O1|CI_exclude_segfault_camelemis_atlas"
+    export ENV_CTEST_EXCLUDES="CI_exclude_fv3jedi|CI_exclude_hang_gnssro_ukmo_intel_O1|CI_exclude_segfault_camelemis_atlas"
 
     # Temporary measure - use sed to disable mpas/mpas-jedi in the intel-oneapi build.
     # Tracking bug: https://github.com/JCSDA-internal/jedi-ci/issues/47

--- a/shell/environment.sh
+++ b/shell/environment.sh
@@ -56,6 +56,10 @@ if [ $JEDI_COMPILER = "intel" ]; then
     COMPILER_FLAGS+=( '-DECBUILD_C_FLAGS_RELWITHDEBINFO="-O1 -g"' '-DECBUILD_CXX_FLAGS_RELWITHDEBINFO="-O1 -g"' '-DECBUILD_Fortran_FLAGS_RELWITHDEBINFO="-O1 -g -fp-model=precise"' )
     export BUILD_PARALLELISM=4
     export ENV_CTEST_EXCLUDES="CI_exclude_hang_gnssro_ukmo_intel_O1|CI_exclude_segfault_camelemis_atlas"
+
+    # Temporary measure - use sed to disable mpas/mpas-jedi in the intel-oneapi build.
+    # Tracking bug: https://github.com/JCSDA-internal/jedi-ci/issues/47
+    sed -i '/PROJECT[[:space:]]\+mpas/d' ${JEDI_BUNDLE_DIR}/CMakeLists.txt    
 fi
 
 if [ $JEDI_COMPILER = "clang" ]; then

--- a/shell/environment.sh
+++ b/shell/environment.sh
@@ -42,6 +42,7 @@ export TEST_ROOT="${WORKDIR}"
 export JEDI_BUNDLE_DIR="${WORKDIR}/bundle"
 export CI_SCRIPTS_DIR=$WORKDIR/bundle/jedi_ci_resources
 export BUILD_PARALLELISM=5
+export ENV_EXCLUDES=""
 
 
 # Set compiler-specific flags and options specific to different tool chains. The
@@ -53,6 +54,7 @@ if [ $JEDI_COMPILER = "intel" ]; then
     # Compiling with -O2 is too slow and uses too much memory
     COMPILER_FLAGS+=( '-DECBUILD_C_FLAGS_RELWITHDEBINFO="-O1 -g"' '-DECBUILD_CXX_FLAGS_RELWITHDEBINFO="-O1 -g"' '-DECBUILD_Fortran_FLAGS_RELWITHDEBINFO="-O1 -g -fp-model=precise"' )
     export BUILD_PARALLELISM=4
+    export ENV_EXCLUDES="CI_exclude_hang_gnssro_ukmo_intel_O1|CI_exclude_segfault_camelemis_atlas"
 fi
 
 if [ $JEDI_COMPILER = "clang" ]; then

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -254,9 +254,9 @@ util.check_run_start_test $TRIGGER_REPO_FULL $FIRST_CHECK_RUN_ID
 
 # Run unit tests.
 if [ "${UNIT_RUN_ID}" -eq 0 ]; then
-    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}|${CTEST_EXCLUDE}") --timeout 500 -C RelWithDebInfo -D ExperimentalTest
+    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}") --timeout 500 -C RelWithDebInfo -D ExperimentalTest
 else
-    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}) -L $UNITTEST_TAG --timeout 500 -C RelWithDebInfo -D ExperimentalTest
+    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}") -L $UNITTEST_TAG --timeout 500 -C RelWithDebInfo -D ExperimentalTest
 fi
 
 # Upload ctests.

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -254,9 +254,9 @@ util.check_run_start_test $TRIGGER_REPO_FULL $FIRST_CHECK_RUN_ID
 
 # Run unit tests.
 if [ "${UNIT_RUN_ID}" -eq 0 ]; then
-    ctest --timeout 500 -C RelWithDebInfo -D ExperimentalTest
+    ctest $(util.ctest_LE_flag "${ENV_EXCLUDES}|${CTEST_EXCLUDE}") --timeout 500 -C RelWithDebInfo -D ExperimentalTest
 else
-    ctest -L $UNITTEST_TAG --timeout 500 -C RelWithDebInfo -D ExperimentalTest
+    ctest $(util.ctest_LE_flag "${ENV_EXCLUDES}) -L $UNITTEST_TAG --timeout 500 -C RelWithDebInfo -D ExperimentalTest
 fi
 
 # Upload ctests.
@@ -346,7 +346,7 @@ TEST_TAG=$(head -1 "${BUILD_DIR}/Testing/TAG")
 util.check_run_start_test $TRIGGER_REPO_FULL $SECOND_CHECK_RUN_ID
 
 # Run integration tests.
-ctest -LE "${UNITTEST_TAG}|gsibec|rttov|oasim|ropp-ufo" --timeout 180 -C RelWithDebInfo -D ExperimentalTest
+ctest $(util.ctest_LE_flag "${ENV_EXCLUDES}|${UNITTEST_TAG}|gsibec|rttov|oasim|ropp-ufo") --timeout 180 -C RelWithDebInfo -D ExperimentalTest
 
 # Upload ctests.
 ctest -C RelWithDebInfo -D ExperimentalSubmit -M Continuous -- --track Continuous --group Continuous

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -254,9 +254,9 @@ util.check_run_start_test $TRIGGER_REPO_FULL $FIRST_CHECK_RUN_ID
 
 # Run unit tests.
 if [ "${UNIT_RUN_ID}" -eq 0 ]; then
-    ctest $(util.ctest_LE_flag "${ENV_EXCLUDES}|${CTEST_EXCLUDE}") --timeout 500 -C RelWithDebInfo -D ExperimentalTest
+    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}|${CTEST_EXCLUDE}") --timeout 500 -C RelWithDebInfo -D ExperimentalTest
 else
-    ctest $(util.ctest_LE_flag "${ENV_EXCLUDES}) -L $UNITTEST_TAG --timeout 500 -C RelWithDebInfo -D ExperimentalTest
+    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}) -L $UNITTEST_TAG --timeout 500 -C RelWithDebInfo -D ExperimentalTest
 fi
 
 # Upload ctests.
@@ -346,7 +346,7 @@ TEST_TAG=$(head -1 "${BUILD_DIR}/Testing/TAG")
 util.check_run_start_test $TRIGGER_REPO_FULL $SECOND_CHECK_RUN_ID
 
 # Run integration tests.
-ctest $(util.ctest_LE_flag "${ENV_EXCLUDES}|${UNITTEST_TAG}|gsibec|rttov|oasim|ropp-ufo") --timeout 180 -C RelWithDebInfo -D ExperimentalTest
+ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}|${UNITTEST_TAG}|gsibec|rttov|oasim|ropp-ufo") --timeout 180 -C RelWithDebInfo -D ExperimentalTest
 
 # Upload ctests.
 ctest -C RelWithDebInfo -D ExperimentalSubmit -M Continuous -- --track Continuous --group Continuous

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -270,7 +270,7 @@ echo "CDash URL: $(util.create_cdash_url "${BUILD_DIR}/Testing")"
 # if the unit run id is 0 then the first run is an integration test.
 ALLOWED_UNIT_FAIL_RATE=0
 if [ $UNITTEST_TAG = 'ufo' ] || [ $UNIT_RUN_ID -eq 0 ]; then
-    ALLOWED_UNIT_FAIL_RATE=1
+    ALLOWED_UNIT_FAIL_RATE=0
 fi
 
 # Close out the check run for unit tests and mark success or failure.
@@ -360,7 +360,7 @@ ls -al "${BUILD_DIR}/Testing/${TEST_TAG}/"
 
 # Complete integration tests and allow a failure rate up to 3%
 
-export ALLOWED_INTEGRATION_FAIL_RATE=3
+export ALLOWED_INTEGRATION_FAIL_RATE=0
 util.check_run_end $TRIGGER_REPO_FULL $SECOND_CHECK_RUN_ID $ALLOWED_INTEGRATION_FAIL_RATE
 
 # Upload codecov data if gcc compiler is used.

--- a/shell/util.sh
+++ b/shell/util.sh
@@ -292,3 +292,23 @@ util.check_run_eval_test_xml() {
     fi
     return 1
 }
+
+# This function generates a ctest label exclude flag from a given
+# regex input if and only if the input is not empty. Otherwise it
+# Returns the empty string preventing ctest from receiving an empty flag.
+# This function is tolerant of extraneous pipes created by appending
+# nullable regex components with pipes.
+# Args:
+#     $1: Regex of test labels to exclude, or empty string to exclude no labels.
+util.ctest_LE_flag() {
+    # Accept input, if it includes leading or trailing pipe, remove it.
+    exclude_regex="$(echo "${1}" | sed 's/|$//' | sed 's/^|//')"
+
+    # If input regex is zero, we return no flag.
+    if [ -z "${exclude_regex}" ]; then
+        printf ""
+        return 0
+    fi
+    printf "\-LE ${exclude_regex}"
+    return 0
+}

--- a/shell/util.sh
+++ b/shell/util.sh
@@ -306,9 +306,9 @@ util.ctest_LE_flag() {
 
     # If input regex is zero, we return no flag.
     if [ -z "${exclude_regex}" ]; then
-        printf ""
+        echo ""
         return 0
     fi
-    printf "\-LE ${exclude_regex}"
+    echo "-LE ${exclude_regex}"
     return 0
 }


### PR DESCRIPTION
I've added a new util function `util.ctest_LE_flag` used to inject the correct label exclude flag. When no labels are specified there will be no flag passed. When labels are specified then we will pass `-LE label|regex|here`. 

I have manually tested this code.

Once this change is submitted we will verify function with the existing intel stack. Then I can push the updated image references to cloud formation.


## Issues:

Fixes: https://github.com/JCSDA-internal/jedi-ci/issues/44
Fixes: https://github.com/JCSDA-internal/jedi-ci/issues/45
Followup issue: https://github.com/JCSDA-internal/jedi-ci/issues/47

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation __N/A__
