### PR TITLE
More fixes for spack-stack 2 rollout

### DIFF
--- a/shell/environment.sh
+++ b/shell/environment.sh
@@ -59,7 +59,10 @@ if [ $JEDI_COMPILER = "intel" ]; then
 
     # Temporary measure - use sed to disable mpas/mpas-jedi in the intel-oneapi build.
     # Tracking bug: https://github.com/JCSDA-internal/jedi-ci/issues/47
-    sed -i '/PROJECT[[:space:]]\+mpas/d' ${JEDI_BUNDLE_DIR}/CMakeLists.txt    
+    sed -i '/PROJECT[[:space:]]\+mpas/d' ${JEDI_BUNDLE_DIR}/CMakeLists.txt
+    if [ -f "${JEDI_BUNDLE_DIR}/CMakeLists.txt.integration" ]; then
+        sed -i '/PROJECT[[:space:]]\+mpas/d' ${JEDI_BUNDLE_DIR}/CMakeLists.txt.integration
+    fi
 fi
 
 if [ $JEDI_COMPILER = "clang" ]; then

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -145,6 +145,10 @@ set -x
 # Setup and run tests.
 #
 
+# Temporary bugfix; update awscrt because the spack-provded version is too old.
+# BUG: https://github.com/JCSDA-internal/jedi-ci/issues/50
+pip install --upgrade awscrt
+
 # Extract just the repo name from the full repository path
 TRIGGER_REPO=$(echo "$TRIGGER_REPO_FULL" | cut -d'/' -f2)
 


### PR DESCRIPTION
1) update awscrt because the spack-stack provided package is too old: https://github.com/JCSDA-internal/jedi-ci/issues/50

2) Fix the build issue in oneapi integration tests where mpas projects were not cleared from the integration test CMakeLists.txt file