### PR TITLE
Add '-DBUILD_GSIBEC=ON' to default jedi-ci invocation

### DIFF
--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -231,6 +231,7 @@ cd "${BUILD_DIR}"
 
 ecbuild \
       -Wno-dev \
+      -DBUILD_GSIBEC=ON \
       -DCMAKE_BUILD_TYPE=RelWithDebInfo \
       -DCDASH_OVERRIDE_SYSTEM_NAME="${JEDI_COMPILER}-Container" \
       -DCDASH_OVERRIDE_SITE=AWSBatch \
@@ -325,6 +326,7 @@ fi
 
 ecbuild \
     -Wno-dev \
+    -DBUILD_GSIBEC=ON \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DCDASH_OVERRIDE_SYSTEM_NAME="${JEDI_COMPILER}-Container" \
     -DCDASH_OVERRIDE_SITE=AWSBatch \


### PR DESCRIPTION
This change moves our CI system to build gsibec in the bundle.

## Testing notes

This change is a necessary prerequisite for the revised spack-stack image rollout. Luckily this flag does not break the existing build with spack-provided gsibec.

Testing with current containe: [all tests pass in this oops check run](https://github.com/JCSDA-internal/oops/pull/3172/checks?check_run_id=62671861672)

Testing of revised gsibec containers: __Passed locally__

## Bugs:

This PR is one of two steps to resolving https://github.com/JCSDA-internal/jedi-ci/issues/53  ; `sp` library causes fv3 test failures.


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation __N/A__
- [x] I have run the unit tests before creating the PR
