### PR TITLE
Add new CI exclude tags.

### DIFF
--- a/shell/environment.sh
+++ b/shell/environment.sh
@@ -47,7 +47,7 @@ export BUILD_PARALLELISM=5
 # Set compiler-specific flags and options specific to different tool chains. The
 # COMPILER_FLAGS array is used in the ecbuild invocation.
 export COMPILER_FLAGS=( '-DCMAKE_DISABLE_FIND_PACKAGE_bufr_query=ON' )
-export ENV_CTEST_EXCLUDES=""
+export ENV_CTEST_EXCLUDES="nightly|ci_flake_disable"
 
 if [ $JEDI_COMPILER = "intel" ]; then
     source /opt/intel/oneapi/compiler/latest/env/vars.sh
@@ -55,7 +55,7 @@ if [ $JEDI_COMPILER = "intel" ]; then
     # Compiling with -O2 is too slow and uses too much memory
     COMPILER_FLAGS+=( '-DECBUILD_C_FLAGS_RELWITHDEBINFO=-O1 -g' '-DECBUILD_CXX_FLAGS_RELWITHDEBINFO=-O1 -g' '-DECBUILD_Fortran_FLAGS_RELWITHDEBINFO=-O1 -g -fp-model=precise' )
     export BUILD_PARALLELISM=4
-    export ENV_CTEST_EXCLUDES="CI_exclude_fv3jedi|CI_exclude_hang_gnssro_ukmo_intel_O1|CI_exclude_segfault_camelemis_atlas"
+    export ENV_CTEST_EXCLUDES="${ENV_CTEST_EXCLUDES}|ci_oneapi_disable|CI_exclude_fv3jedi|CI_exclude_hang_gnssro_ukmo_intel_O1|CI_exclude_segfault_camelemis_atlas"
 
     # Temporary measure - use sed to disable mpas/mpas-jedi in the intel-oneapi build.
     # Tracking bug: https://github.com/JCSDA-internal/jedi-ci/issues/47
@@ -68,10 +68,12 @@ fi
 if [ $JEDI_COMPILER = "clang" ]; then
     export CC=/usr/bin/clang
     export CXX=/usr/bin/clang++
+    export ENV_CTEST_EXCLUDES="${ENV_CTEST_EXCLUDES}|ci_clang_disable"
 fi
 
 if [ $JEDI_COMPILER = "gcc" ] || [ $JEDI_COMPILER = "gcc11" ]; then
     export BUILD_PARALLELISM=4
+    export ENV_CTEST_EXCLUDES="${ENV_CTEST_EXCLUDES}|ci_gcc_disable"
 fi
 
 


### PR DESCRIPTION
Initial step towards tag logic described here: https://github.com/JCSDA-internal/jedi-ci/issues/57



This adds the new exclude `nightly`, `ci_flake_disable`, and gcc/oneapi/clang disables but does not remove the old tags allowing the old tags to be deleted/migrated.
