### PR TITLE
ctest flag fixes - use consistent flags for CDash test mode and action

### DIFF
--- a/ci_action/library/aws_client.py
+++ b/ci_action/library/aws_client.py
@@ -231,6 +231,10 @@ def submit_test_batch_job(
                     'name': 'TEST_SCRIPT',
                     'value': test_script,
                 },
+                {
+                    'name': 'CDASH_TEST_MODE',
+                    'value': 'Continuous',
+                },
             ],
         },
     )

--- a/ci_action/library/aws_client.py
+++ b/ci_action/library/aws_client.py
@@ -231,10 +231,6 @@ def submit_test_batch_job(
                     'name': 'TEST_SCRIPT',
                     'value': test_script,
                 },
-                {
-                    'name': 'CDASH_TEST_MODE',
-                    'value': 'Continuous',
-                },
             ],
         },
     )

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -272,16 +272,14 @@ fi
 # Upload ctests.
 ctest -C RelWithDebInfo -M Experimental -T Submit --group Continuous
 
-echo "CDash URL: $(util.create_cdash_url "${BUILD_DIR}/Testing")"
+# Debug info for cdash test tags. Do not remove until https://github.com/JCSDA-internal/jedi-ci/issues/70 is resolved. 
+find ${BUILD_DIR}/Testing -type f
+find "${BUILD_DIR}/Testing" -type f -name "Done.xml" -exec head -n5 {} \;
+CDASH_TEST_TAG=$(head -1 "${BUILD_DIR}/Testing/TAG")
+ls -al "${BUILD_DIR}/Testing/${CDASH_TEST_TAG}/"
+# End of debug info.
 
-# This is a temporary hack to allow UFO tests to pass until we resolve the
-# flakes and/or persistent failures. Once UFO testing failures are resolved
-# we can hard-code this failure rate to zero and remove this logic. Also
-# if the unit run id is 0 then the first run is an integration test.
-ALLOWED_UNIT_FAIL_RATE=0
-if [ "${UNITTEST_TAG}" = 'ufo' ] || [ "${UNIT_RUN_ID}" -eq 0 ]; then
-    ALLOWED_UNIT_FAIL_RATE=0
-fi
+echo "CDash URL: $(util.create_cdash_url "${BUILD_DIR}/Testing")"
 
 # Close out the check run for unit tests and mark success or failure.
 util.check_run_end $TRIGGER_REPO_FULL $FIRST_CHECK_RUN_ID $ALLOWED_UNIT_FAIL_RATE
@@ -351,9 +349,6 @@ if [ $? -ne 0 ]; then
     exit 0
 fi
 
-# Delete test output to force re-generation of BuildID
-TEST_TAG=$(head -1 "${BUILD_DIR}/Testing/TAG")
-
 util.check_run_start_test $TRIGGER_REPO_FULL $SECOND_CHECK_RUN_ID
 
 # Run integration tests.
@@ -362,12 +357,14 @@ ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}|${UNITTEST_TAG}|tier2|gsibec|r
 # Upload ctests.
 ctest -C RelWithDebInfo -M "${CDASH_TEST_MODE}" -T Submit --group Continuous
 
+# Debug info for cdash test tags. Do not remove until https://github.com/JCSDA-internal/jedi-ci/issues/70 is resolved. 
 find ${BUILD_DIR}/Testing -type f
-find ${BUILD_DIR}/Testing -type f -exec head -n5 {} \;
+find "${BUILD_DIR}/Testing" -type f -name "Done.xml" -exec head -n5 {} \;
+CDASH_TEST_TAG=$(head -1 "${BUILD_DIR}/Testing/TAG")
+ls -al "${BUILD_DIR}/Testing/${CDASH_TEST_TAG}/"
+# End of debug info.
 
 echo "CDash URL: $(util.create_cdash_url "${BUILD_DIR}/Testing")"
-TEST_TAG=$(head -1 "${BUILD_DIR}/Testing/TAG")
-ls -al "${BUILD_DIR}/Testing/${TEST_TAG}/"
 
 # Complete integration tests and allow a failure rate up to 3%
 

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -270,7 +270,7 @@ else
 fi
 
 # Upload ctests.
-ctest -C RelWithDebInfo -M Experimental -T Submit --track Continuous --group Continuous
+ctest -C RelWithDebInfo -T Submit --track Continuous --group Continuous
 
 # Debug info for cdash test tags. Do not remove until https://github.com/JCSDA-internal/jedi-ci/issues/70 is resolved. 
 find ${BUILD_DIR}/Testing -type f
@@ -353,10 +353,10 @@ fi
 util.check_run_start_test $TRIGGER_REPO_FULL $SECOND_CHECK_RUN_ID
 
 # Run integration tests.
-ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}|${UNITTEST_TAG}|tier2|gsibec|rttov|oasim|ropp-ufo") --timeout 180 -C RelWithDebInfo -M Experimental -T Test
+ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}|${UNITTEST_TAG}|tier2|gsibec|rttov|oasim|ropp-ufo") --timeout 180 -C RelWithDebInfo -T Test
 
 # Upload ctests.
-ctest -C RelWithDebInfo -M Experimental -T Submit --track Continuous --group Continuous
+ctest -C RelWithDebInfo -T Submit --track Continuous --group Continuous
 
 # Debug info for cdash test tags. Do not remove until https://github.com/JCSDA-internal/jedi-ci/issues/70 is resolved. 
 find ${BUILD_DIR}/Testing -type f

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -68,6 +68,11 @@ if [ -z "${TRIGGER_REPO_FULL}" ]; then
     echo "Var TRIGGER_REPO_FULL must be set."
     valid_environment_found="no"
 fi
+if [ -z "${CDASH_TEST_MODE}" ]; then
+    # This variable is set by AWS Batch.
+    echo "Var CDASH_TEST_MODE must be set; allowed values include Continuous and Nightly."
+    valid_environment_found="no"
+fi
 
 
 if [ $valid_environment_found == "no" ]; then
@@ -89,6 +94,7 @@ OMPI_ALLOW_RUN_AS_ROOT=${OMPI_ALLOW_RUN_AS_ROOT}
 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=${OMPI_ALLOW_RUN_AS_ROOT_CONFIRM}
 OMPI_MCA_rmaps_base_oversubscribe=${OMPI_MCA_rmaps_base_oversubscribe}
 CI_SCRIPTS_DIR=${CI_SCRIPTS_DIR}
+CDASH_TEST_MODE=${CDASH_TEST_MODE}
 CC="${CC}"
 CXX="${CXX}"
 FC="${FC}"
@@ -264,13 +270,13 @@ util.check_run_start_test $TRIGGER_REPO_FULL $FIRST_CHECK_RUN_ID
 
 # Run unit tests.
 if [ "${UNIT_RUN_ID}" -eq 0 ]; then
-    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}") --timeout 500 -C RelWithDebInfo -D ExperimentalTest
+    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}") --timeout 500 -C RelWithDebInfo -M "${CDASH_TEST_MODE}" -T Test
 else
-    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}") -L "${UNITTEST_TAG}" --timeout 500 -C RelWithDebInfo -D ExperimentalTest
+    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}") -L "${UNITTEST_TAG}" --timeout 500 -C RelWithDebInfo -M "${CDASH_TEST_MODE}" -T Test
 fi
 
 # Upload ctests.
-ctest -C RelWithDebInfo -D ExperimentalSubmit -M Continuous --track Continuous --group Continuous
+ctest -C RelWithDebInfo -M "${CDASH_TEST_MODE}" -T Submit
 
 echo "CDash URL: $(util.create_cdash_url "${BUILD_DIR}/Testing")"
 
@@ -357,10 +363,10 @@ TEST_TAG=$(head -1 "${BUILD_DIR}/Testing/TAG")
 util.check_run_start_test $TRIGGER_REPO_FULL $SECOND_CHECK_RUN_ID
 
 # Run integration tests.
-ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}|${UNITTEST_TAG}|tier2|gsibec|rttov|oasim|ropp-ufo") --timeout 180 -C RelWithDebInfo -D ExperimentalTest
+ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}|${UNITTEST_TAG}|tier2|gsibec|rttov|oasim|ropp-ufo") --timeout 180 -C RelWithDebInfo -M "${CDASH_TEST_MODE}" -T Test
 
 # Upload ctests.
-ctest -C RelWithDebInfo -D ExperimentalSubmit -M Continuous --track Continuous --group Continuous
+ctest -C RelWithDebInfo -M "${CDASH_TEST_MODE}" -T Submit
 
 find ${BUILD_DIR}/Testing -type f
 find ${BUILD_DIR}/Testing -type f -exec head -n5 {} \;

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -266,7 +266,7 @@ util.check_run_start_test $TRIGGER_REPO_FULL $FIRST_CHECK_RUN_ID
 if [ "${UNIT_RUN_ID}" -eq 0 ]; then
     ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}") --timeout 500 -C RelWithDebInfo -D ExperimentalTest
 else
-    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}") -L $UNITTEST_TAG --timeout 500 -C RelWithDebInfo -D ExperimentalTest
+    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}") -L "${UNITTEST_TAG}" --timeout 500 -C RelWithDebInfo -D ExperimentalTest
 fi
 
 # Upload ctests.
@@ -279,7 +279,7 @@ echo "CDash URL: $(util.create_cdash_url "${BUILD_DIR}/Testing")"
 # we can hard-code this failure rate to zero and remove this logic. Also
 # if the unit run id is 0 then the first run is an integration test.
 ALLOWED_UNIT_FAIL_RATE=0
-if [ $UNITTEST_TAG = 'ufo' ] || [ $UNIT_RUN_ID -eq 0 ]; then
+if [ "${UNITTEST_TAG}" = 'ufo' ] || [ "${UNIT_RUN_ID}" -eq 0 ]; then
     ALLOWED_UNIT_FAIL_RATE=0
 fi
 

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -68,11 +68,6 @@ if [ -z "${TRIGGER_REPO_FULL}" ]; then
     echo "Var TRIGGER_REPO_FULL must be set."
     valid_environment_found="no"
 fi
-if [ -z "${CDASH_TEST_MODE}" ]; then
-    # This variable is set by AWS Batch.
-    echo "Var CDASH_TEST_MODE must be set; allowed values include Continuous and Nightly."
-    valid_environment_found="no"
-fi
 
 
 if [ $valid_environment_found == "no" ]; then
@@ -94,7 +89,6 @@ OMPI_ALLOW_RUN_AS_ROOT=${OMPI_ALLOW_RUN_AS_ROOT}
 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=${OMPI_ALLOW_RUN_AS_ROOT_CONFIRM}
 OMPI_MCA_rmaps_base_oversubscribe=${OMPI_MCA_rmaps_base_oversubscribe}
 CI_SCRIPTS_DIR=${CI_SCRIPTS_DIR}
-CDASH_TEST_MODE=${CDASH_TEST_MODE}
 CC="${CC}"
 CXX="${CXX}"
 FC="${FC}"
@@ -270,13 +264,13 @@ util.check_run_start_test $TRIGGER_REPO_FULL $FIRST_CHECK_RUN_ID
 
 # Run unit tests.
 if [ "${UNIT_RUN_ID}" -eq 0 ]; then
-    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}") --timeout 500 -C RelWithDebInfo -M "${CDASH_TEST_MODE}" -T Test
+    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}") --timeout 500 -C RelWithDebInfo -M Experimental -T Test
 else
-    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}") -L "${UNITTEST_TAG}" --timeout 500 -C RelWithDebInfo -M "${CDASH_TEST_MODE}" -T Test
+    ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}") -L "${UNITTEST_TAG}" --timeout 500 -C RelWithDebInfo -M Experimental -T Test
 fi
 
 # Upload ctests.
-ctest -C RelWithDebInfo -M "${CDASH_TEST_MODE}" -T Submit
+ctest -C RelWithDebInfo -M Experimental -T Submit --group Continuous
 
 echo "CDash URL: $(util.create_cdash_url "${BUILD_DIR}/Testing")"
 
@@ -363,10 +357,10 @@ TEST_TAG=$(head -1 "${BUILD_DIR}/Testing/TAG")
 util.check_run_start_test $TRIGGER_REPO_FULL $SECOND_CHECK_RUN_ID
 
 # Run integration tests.
-ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}|${UNITTEST_TAG}|tier2|gsibec|rttov|oasim|ropp-ufo") --timeout 180 -C RelWithDebInfo -M "${CDASH_TEST_MODE}" -T Test
+ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}|${UNITTEST_TAG}|tier2|gsibec|rttov|oasim|ropp-ufo") --timeout 180 -C RelWithDebInfo -M Experimental -T Test
 
 # Upload ctests.
-ctest -C RelWithDebInfo -M "${CDASH_TEST_MODE}" -T Submit
+ctest -C RelWithDebInfo -M "${CDASH_TEST_MODE}" -T Submit --group Continuous
 
 find ${BUILD_DIR}/Testing -type f
 find ${BUILD_DIR}/Testing -type f -exec head -n5 {} \;

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -356,7 +356,7 @@ util.check_run_start_test $TRIGGER_REPO_FULL $SECOND_CHECK_RUN_ID
 ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}|${UNITTEST_TAG}|tier2|gsibec|rttov|oasim|ropp-ufo") --timeout 180 -C RelWithDebInfo -M Experimental -T Test
 
 # Upload ctests.
-ctest -C RelWithDebInfo -M "${CDASH_TEST_MODE}" -T Submit --track Continuous --group Continuous
+ctest -C RelWithDebInfo -M Experimental -T Submit --track Continuous --group Continuous
 
 # Debug info for cdash test tags. Do not remove until https://github.com/JCSDA-internal/jedi-ci/issues/70 is resolved. 
 find ${BUILD_DIR}/Testing -type f

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -282,6 +282,7 @@ ls -al "${BUILD_DIR}/Testing/${CDASH_TEST_TAG}/"
 echo "CDash URL: $(util.create_cdash_url "${BUILD_DIR}/Testing")"
 
 # Close out the check run for unit tests and mark success or failure.
+export ALLOWED_UNIT_FAIL_RATE=0
 util.check_run_end $TRIGGER_REPO_FULL $FIRST_CHECK_RUN_ID $ALLOWED_UNIT_FAIL_RATE
 
 # Decision point: if the unit tests failed then we should mark the integration

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -270,7 +270,7 @@ else
 fi
 
 # Upload ctests.
-ctest -C RelWithDebInfo -M Experimental -T Submit --group Continuous
+ctest -C RelWithDebInfo -M Experimental -T Submit --track Continuous --group Continuous
 
 # Debug info for cdash test tags. Do not remove until https://github.com/JCSDA-internal/jedi-ci/issues/70 is resolved. 
 find ${BUILD_DIR}/Testing -type f
@@ -356,7 +356,7 @@ util.check_run_start_test $TRIGGER_REPO_FULL $SECOND_CHECK_RUN_ID
 ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}|${UNITTEST_TAG}|tier2|gsibec|rttov|oasim|ropp-ufo") --timeout 180 -C RelWithDebInfo -M Experimental -T Test
 
 # Upload ctests.
-ctest -C RelWithDebInfo -M "${CDASH_TEST_MODE}" -T Submit --group Continuous
+ctest -C RelWithDebInfo -M "${CDASH_TEST_MODE}" -T Submit --track Continuous --group Continuous
 
 # Debug info for cdash test tags. Do not remove until https://github.com/JCSDA-internal/jedi-ci/issues/70 is resolved. 
 find ${BUILD_DIR}/Testing -type f

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -282,7 +282,7 @@ ls -al "${BUILD_DIR}/Testing/${CDASH_TEST_TAG}/"
 echo "CDash URL: $(util.create_cdash_url "${BUILD_DIR}/Testing")"
 
 # Close out the check run for unit tests and mark success or failure.
-export ALLOWED_UNIT_FAIL_RATE=0
+ALLOWED_UNIT_FAIL_RATE=0
 util.check_run_end $TRIGGER_REPO_FULL $FIRST_CHECK_RUN_ID $ALLOWED_UNIT_FAIL_RATE
 
 # Decision point: if the unit tests failed then we should mark the integration
@@ -369,7 +369,7 @@ echo "CDash URL: $(util.create_cdash_url "${BUILD_DIR}/Testing")"
 
 # Complete integration tests and allow a failure rate up to 3%
 
-export ALLOWED_INTEGRATION_FAIL_RATE=0
+ALLOWED_INTEGRATION_FAIL_RATE=0
 util.check_run_end $TRIGGER_REPO_FULL $SECOND_CHECK_RUN_ID $ALLOWED_INTEGRATION_FAIL_RATE
 
 # Upload codecov data if gcc compiler is used.


### PR DESCRIPTION
This PR contains a small collection of fixes for our CI system. I'll add comments noting the nature of each change. Shortly I'll sumarize the changes here.

* Added debug output to help with the UTC date-spanning test bug: #70
* Hardcoded test fail rate (currently 0) and eliminated unnecessary UFO logic.
* CTest flag fixes stop using `-D ExperimentalSubmit -M Continuous` which is an undefined state that should not be possible.

This branch was tested here: https://github.com/JCSDA-internal/oops/pull/3242