### PR TITLE
Add logging feature that will be used to construct status dash.

### DIFF
--- a/ci_action/implementation.py
+++ b/ci_action/implementation.py
@@ -293,6 +293,7 @@ def prepare_and_launch_ci_test(
             trigger_pr=str(config['pull_request_number']),
             check_run_id=check_run_id,
             test_script=config['test_script'],
+            is_scheduled=is_scheduled,
         )
         job_arn = job['jobArn']
         LOG.info(

--- a/ci_action/library/aws_client.py
+++ b/ci_action/library/aws_client.py
@@ -168,6 +168,7 @@ def submit_test_batch_job(
         trigger_pr: str,
         check_run_id: str,
         test_script: str,
+        is_scheduled: bool,
 ):
     """Submit a CI batch job with updated environment variables."""
     job_name = f'jedi-ci-{repo_name}-{build_id}-{config.build_environment}'
@@ -219,6 +220,11 @@ def submit_test_batch_job(
                 {
                     'name': 'TEST_SCRIPT',
                     'value': test_script,
+                },
+                {
+                    # Whether this is a scheduled (nightly) run.
+                    'name': 'IS_SCHEDULED',
+                    'value': 'yes' if is_scheduled else 'no',
                 },
             ],
         },

--- a/shell/bootstrap_test.sh
+++ b/shell/bootstrap_test.sh
@@ -4,11 +4,21 @@ source /opt/spack-environment/activate.sh
 # Directory of this script.
 export SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Setup public log stream.
+# Setup public log stream. Objects are sharded under a YYYYMMDD date prefix to
+# keep later ingestion jobs simple.
 _RANDOM="$(head /dev/urandom | base32 | head -c 8)"
 _REGION="$(aws s3api get-bucket-location --bucket $PUBLIC_LOGS_BUCKET | jq -r .LocationConstraint)"
-export PUBLIC_LOG_S3="s3://${PUBLIC_LOGS_BUCKET}/${BUILD_IDENTITY}-${_RANDOM}.html"
-export PUBLIC_LOG_URL="https://${PUBLIC_LOGS_BUCKET}.s3.${_REGION}.amazonaws.com/${BUILD_IDENTITY}-${_RANDOM}.html"
+_DATE="$(date -u +%Y%m%d)"
+export PUBLIC_LOG_S3="s3://${PUBLIC_LOGS_BUCKET}/${_DATE}/${BUILD_IDENTITY}-${_RANDOM}.html"
+export PUBLIC_LOG_URL="https://${PUBLIC_LOGS_BUCKET}.s3.${_REGION}.amazonaws.com/${_DATE}/${BUILD_IDENTITY}-${_RANDOM}.html"
+
+# Structured status log. The test script appends YAML lifecycle events here
+# (see util.status_log_* functions); we upload it to the public bucket on the
+# same cadence as the build logs so global test-system status can be consumed
+# later to build a dashboard.
+export STATUS_LOG="/tmp/status.log"
+export STATUS_LOG_S3="s3://${PUBLIC_LOGS_BUCKET}/${_DATE}/${BUILD_IDENTITY}-${_RANDOM}.status.yaml"
+export STATUS_LOG_URL="https://${PUBLIC_LOGS_BUCKET}.s3.${_REGION}.amazonaws.com/${_DATE}/${BUILD_IDENTITY}-${_RANDOM}.status.yaml"
 
 # Setup GitHub app credentials.
 cp $SCRIPT_DIR/git_askPass_app_credentials.py /bin/git_askPass_app_credentials.py
@@ -51,6 +61,7 @@ SLEEP_TIME=120  # 2 minutes
 while kill -0 $TEST_PID 2>/dev/null; do
     cat /tmp/build_logs.txt | python -m ansi2html -l > /tmp/build_logs.html
     aws s3 cp /tmp/build_logs.html $PUBLIC_LOG_S3 --content-type "text/html"
+    [ -f "$STATUS_LOG" ] && aws s3 cp "$STATUS_LOG" "$STATUS_LOG_S3" --content-type "text/plain"
     sleep $SLEEP_TIME
     MONITOR_UPLOADS=$((MONITOR_UPLOADS + 1))
     if [[ $MONITOR_UPLOADS == 5 ]]; then
@@ -70,4 +81,5 @@ sleep 1
 set -x
 cat /tmp/build_logs.txt | python -m ansi2html -l > /tmp/build_logs.html
 aws s3 cp /tmp/build_logs.html $PUBLIC_LOG_S3 --content-type "text/html"
+[ -f "$STATUS_LOG" ] && aws s3 cp "$STATUS_LOG" "$STATUS_LOG_S3" --content-type "text/plain"
 df -h

--- a/shell/github_api/check_run.py
+++ b/shell/github_api/check_run.py
@@ -4,6 +4,9 @@ check_run.py manages the GitHub code check representation of our pre-submit
 tests. This script creates the check run, updates the check when tests
 start, and completes the check run when the tests are done.
 
+This script also has several functions for querying the content of the
+test result xml file.
+
 
 ## Subcommands
 
@@ -20,6 +23,9 @@ Other commands:
   * eval_test_xml: Given a passing test percentage, determine if a Test.xml file
                    meets the criteria for acceptance. Exit code of 1 if the test
                    failure rate is above the test fail percentage.
+  * stat_test_xml: Reads a Test.xml file and outputs a json string with the
+                   pass/fail status, count of total tests run, and count of
+                   failing tests.
 
 
 ## Unresolved issues
@@ -264,6 +270,17 @@ PARSER_EVAL.add_argument(
     type=int,
     required=True,
     help='What percentage of tests may fail without failing the test.')
+
+PARSER_STAT = SUBPARSERS.add_parser('stat_test_xml', help='print json with test result counts.')
+# First argument is a hidden flag used to detect this state.
+PARSER_STAT.add_argument(
+    '--stat-xml-flag',
+    action='store_true',
+    default=True,
+    help=argparse.SUPPRESS)
+PARSER_STAT.add_argument(
+    '--test-xml',
+    help='ctest output xml file with detailed test results.')
 
 
 TEST_GENERAL_INFO = textwrap.dedent(f"""
@@ -645,6 +662,21 @@ def eval_test_xml(args):
     sys.exit(0)
 
 
+def stat_test_xml(args):
+    try:
+        results = TestOutput.from_test_xml(args.test_xml)
+        resultsdict = {
+            'status': 'failure' if results.not_passed else 'success',
+            'count_tests': len(results.all_tests),
+            'count_tests_not_passed': len(results.not_passed),
+        }
+    except (OSError, ValueError, TypeError, xml.etree.ElementTree.ParseError):
+        # Missing, omitted, or unparseable Test.xml (e.g. the tests never ran).
+        resultsdict = {'status': 'no_result', 'count_tests': 0, 'count_tests_not_passed': 0}
+    print(json.dumps(resultsdict))
+    sys.exit(0)
+
+
 def print_help(_):
     PARSER.print_help()
 
@@ -657,9 +689,12 @@ if __name__ == '__main__':
     PARSER_UPDATE.set_defaults(func=check_run_update)
     PARSER_END.set_defaults(func=check_run_end)
     PARSER_EVAL.set_defaults(func=eval_test_xml)
+    PARSER_STAT.set_defaults(func=stat_test_xml)
     args = PARSER.parse_args()
 
     if 'eval_xml_flag' in args:
+        args.func(args)
+    elif 'stat_xml_flag' in args:
         args.func(args)
     else:
         app_id = args.app_id

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -151,6 +151,11 @@ pip install --upgrade awscrt
 # Extract just the repo name from the full repository path
 TRIGGER_REPO=$(echo "$TRIGGER_REPO_FULL" | cut -d'/' -f2)
 
+# Initialize the structured status log with run metadata. From here on we
+# append lifecycle events (configure, build, test, upload) so overall test
+# system status can be monitored independently of CDash and GitHub check runs.
+util.status_log_init
+
 # Mark the single check run as building and attach the batch job URL.
 util.check_run_start_build $TRIGGER_REPO_FULL $CHECK_RUN_ID
 
@@ -213,20 +218,24 @@ ecbuild \
       "${COMPILER_FLAGS[@]}" "${JEDI_BUNDLE_DIR}"
 
 if [ $? -ne 0 ]; then
+    util.status_log_event configure failure "Bundle configuration failed"
     util.check_run_fail $TRIGGER_REPO_FULL $CHECK_RUN_ID "Bundle configuration failed"
     util.evaluate_debug_timer_then_cleanup
     exit 0
 fi
+util.status_log_event configure success
 
 # Back-date source files (search "back-date" in this file for an explanation).
 find $JEDI_BUNDLE_DIR -type f -exec touch -d "$SOURCE_BACKDATE_TIMESTAMP" {} \;
 
 make -j $BUILD_PARALLELISM
 if [ $? -ne 0 ]; then
+    util.status_log_event build failure "compilation failed"
     util.check_run_fail $TRIGGER_REPO_FULL $CHECK_RUN_ID "compilation failed"
     util.evaluate_debug_timer_then_cleanup
     exit 0
 fi
+util.status_log_event build success
 
 # Show sccache debug output.
 sccache --show-stats
@@ -240,8 +249,15 @@ util.check_run_start_test $TRIGGER_REPO_FULL $CHECK_RUN_ID
 if [ -n "${UNITTEST_TAG}" ]; then
     ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}") -L "${UNITTEST_TAG}" --timeout 500 -C RelWithDebInfo -M Experimental -T Test
 
+    # Record unit test pass/fail counts to the status log.
+    util.status_log_test_result unit_test "$(util.find_test_xml)"
+
     # Upload unit test results.
-    ctest -C RelWithDebInfo -T Submit --track Continuous --group Continuous
+    if ctest -C RelWithDebInfo -T Submit --track Continuous --group Continuous; then
+        util.status_log_event cdash_upload success "unit"
+    else
+        util.status_log_event cdash_upload failure "unit"
+    fi
 
     # Debug info for cdash test tags. Do not remove until https://github.com/JCSDA-internal/jedi-ci/issues/70 is resolved.
     find ${BUILD_DIR}/Testing -type f
@@ -275,8 +291,15 @@ fi
 # Run integration tests.
 ctest $(util.ctest_LE_flag "${ENV_CTEST_EXCLUDES}|${UNITTEST_TAG}|tier2|gsibec|rttov|oasim|ropp-ufo") --timeout 180 -C RelWithDebInfo -T Test
 
+# Record integration test pass/fail counts to the status log.
+util.status_log_test_result integration_test "$(util.find_test_xml)"
+
 # Upload ctests.
-ctest -C RelWithDebInfo -T Submit --track Continuous --group Continuous
+if ctest -C RelWithDebInfo -T Submit --track Continuous --group Continuous; then
+    util.status_log_event cdash_upload success "integration"
+else
+    util.status_log_event cdash_upload failure "integration"
+fi
 
 # Debug info for cdash test tags. Do not remove until https://github.com/JCSDA-internal/jedi-ci/issues/70 is resolved.
 find ${BUILD_DIR}/Testing -type f
@@ -295,5 +318,6 @@ if [ "$JEDI_COMPILER" = "gcc" ] && [ -f "${JEDI_BUNDLE_DIR}/${TRIGGER_REPO}/.cod
     bash <(curl -s https://codecov.io/bash) -t 53f87271-b490-453c-b891-afd39cb658af -R "${JEDI_BUNDLE_DIR}/${TRIGGER_REPO}"
 fi
 
+util.status_log_event run complete
 util.evaluate_debug_timer_then_cleanup
 echo "test complete"

--- a/shell/util.sh
+++ b/shell/util.sh
@@ -330,7 +330,7 @@ util.status_log_test_result() {
 
     # Parse stats; a missing/unparseable Test.xml yields a "no_result" status.
     local stat_json
-    stat_json="$(${CI_SCRIPTS_DIR}/github_api/check_run.py stat_test_xml --test-xml="${test_xml}")"
+    stat_json="$(${CI_SCRIPTS_DIR}/github_api/check_run.py stat_test_xml --test-xml="${test_xml}")" || stat_json='{"status": "no_result"}'
 
     # Merge the base event object with the parsed stats. Compact (-c) keeps it
     # on one line; JSON flow mappings are valid YAML.

--- a/shell/util.sh
+++ b/shell/util.sh
@@ -256,3 +256,96 @@ util.ctest_LE_flag() {
     echo "-LE ${exclude_regex}"
     return 0
 }
+
+#
+# Structured status logging.
+#
+# Append-only record of the test lifecycle, written as a YAML document: a
+# metadata header followed by an `events:` list, one event per line. Uploaded
+# to the public bucket for aggregation into a global status dashboard. Unlike
+# CDash, this captures failures before or during configure/build.
+#
+# Example output:
+#
+#   repo: JCSDA/ufo
+#   commit: a1b2c3d
+#   pr: "42"
+#   compiler: gcc11
+#   batch_job_id: abc-123
+#   build_identity: ufo-gcc11
+#   public_log_url: https://.../ufo-gcc11-xxxx.html
+#   start_time: 2026-06-03T12:00:00Z
+#   events:
+#     - {time: 2026-06-03T12:01:00Z, event: configure, status: success}
+#     - {time: 2026-06-03T12:45:00Z, event: unit_test, status: failure, passed: 10, failed: 2}
+
+# Status log path. Normally exported by bootstrap_test.sh so the uploader
+# shares the same path.
+export STATUS_LOG="${STATUS_LOG:-/tmp/status.log}"
+
+# Truncate the status log and write the run metadata header, ending with the
+# `events:` key. Call once near the start of the test script; reads run
+# metadata from the environment.
+util.status_log_init() {
+    local ts
+    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    cat > "${STATUS_LOG}" <<EOF
+repo: ${TRIGGER_REPO_FULL}
+commit: ${TRIGGER_SHA}
+pr: "${TRIGGER_PR}"
+compiler: ${JEDI_COMPILER}
+scheduled: "${IS_SCHEDULED:-no}"
+batch_job_id: ${AWS_BATCH_JOB_ID}
+build_identity: ${BUILD_IDENTITY}
+public_log_url: ${PUBLIC_LOG_URL}
+start_time: ${ts}
+events:
+EOF
+}
+
+# Append a single event to the status log as a one-line YAML list item.
+# Args:
+#     $1: event name (e.g. "configure", "build", "unit_test", "cdash_upload").
+#     $2: status (e.g. "start", "success", "failure", "skipped").
+#     $3: (optional) free-form human-readable detail string.
+util.status_log_event() {
+    local event="$1"
+    local status="$2"
+    local detail="${3:-}"
+    local ts
+    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    if [ -n "${detail}" ]; then
+        # Escape embedded double-quotes so the quoted detail stays valid YAML.
+        detail="${detail//\"/\\\"}"
+        printf '  - {time: %s, event: %s, status: %s, detail: "%s"}\n' \
+            "${ts}" "${event}" "${status}" "${detail}" >> "${STATUS_LOG}"
+    else
+        printf '  - {time: %s, event: %s, status: %s}\n' \
+            "${ts}" "${event}" "${status}" >> "${STATUS_LOG}"
+    fi
+}
+
+# Append a test-result event with passed/failed counts parsed from a ctest
+# Test.xml. Each executed test is a <Test Status="..."> element; anything not
+# "passed" counts as failed (matching check_run.py). Status is "success" only
+# if at least one test ran and none failed.
+# Args:
+#     $1: event name ("unit_test" or "integration_test").
+#     $2: path to the ctest Test.xml file.
+util.status_log_test_result() {
+    local event="$1"
+    local test_xml="$2"
+    local total=0 passed=0 failed=0 status="failure"
+    if [ -f "${test_xml}" ]; then
+        total=$(grep -oE "<Test Status=" "${test_xml}" 2>/dev/null | wc -l)
+        passed=$(grep -oE "<Test Status=[\"']passed[\"']" "${test_xml}" 2>/dev/null | wc -l)
+        failed=$((total - passed))
+        if [ "${failed}" -eq 0 ] && [ "${total}" -gt 0 ]; then
+            status="success"
+        fi
+    fi
+    local ts
+    ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf '  - {time: %s, event: %s, status: %s, passed: %s, failed: %s}\n' \
+        "${ts}" "${event}" "${status}" "${passed}" "${failed}" >> "${STATUS_LOG}"
+}

--- a/shell/util.sh
+++ b/shell/util.sh
@@ -283,9 +283,7 @@ util.ctest_LE_flag() {
 # shares the same path.
 export STATUS_LOG="${STATUS_LOG:-/tmp/status.log}"
 
-# Truncate the status log and write the run metadata header, ending with the
-# `events:` key. Call once near the start of the test script; reads run
-# metadata from the environment.
+# Initialize the status log document. Call once at the start of the test run.
 util.status_log_init() {
     local ts
     ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
@@ -303,49 +301,40 @@ events:
 EOF
 }
 
-# Append a single event to the status log as a one-line YAML list item.
+# Append a single lifecycle event to the status log.
 # Args:
 #     $1: event name (e.g. "configure", "build", "unit_test", "cdash_upload").
 #     $2: status (e.g. "start", "success", "failure", "skipped").
-#     $3: (optional) free-form human-readable detail string.
+#     $3: (optional) free-form human-readable detail string, defaults to "".
 util.status_log_event() {
     local event="$1"
     local status="$2"
     local detail="${3:-}"
     local ts
     ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    if [ -n "${detail}" ]; then
-        # Escape embedded double-quotes so the quoted detail stays valid YAML.
-        detail="${detail//\"/\\\"}"
-        printf '  - {time: %s, event: %s, status: %s, detail: "%s"}\n' \
-            "${ts}" "${event}" "${status}" "${detail}" >> "${STATUS_LOG}"
-    else
-        printf '  - {time: %s, event: %s, status: %s}\n' \
-            "${ts}" "${event}" "${status}" >> "${STATUS_LOG}"
-    fi
+    printf "  - " >> "${STATUS_LOG}"
+    jq -cn --arg time "${ts}" --arg event "${event}" --arg status "${status}" --arg detail "${detail}" \
+        '{time: $time, event: $event, status: $status, detail: $detail}' >> "${STATUS_LOG}"
 }
 
-# Append a test-result event with passed/failed counts parsed from a ctest
-# Test.xml. Each executed test is a <Test Status="..."> element; anything not
-# "passed" counts as failed (matching check_run.py). Status is "success" only
-# if at least one test ran and none failed.
+# Append a test-result event, with status and test counts parsed from a ctest
+# Test.xml by check_run.py.
 # Args:
 #     $1: event name ("unit_test" or "integration_test").
 #     $2: path to the ctest Test.xml file.
 util.status_log_test_result() {
     local event="$1"
     local test_xml="$2"
-    local total=0 passed=0 failed=0 status="failure"
-    if [ -f "${test_xml}" ]; then
-        total=$(grep -oE "<Test Status=" "${test_xml}" 2>/dev/null | wc -l)
-        passed=$(grep -oE "<Test Status=[\"']passed[\"']" "${test_xml}" 2>/dev/null | wc -l)
-        failed=$((total - passed))
-        if [ "${failed}" -eq 0 ] && [ "${total}" -gt 0 ]; then
-            status="success"
-        fi
-    fi
     local ts
     ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    printf '  - {time: %s, event: %s, status: %s, passed: %s, failed: %s}\n' \
-        "${ts}" "${event}" "${status}" "${passed}" "${failed}" >> "${STATUS_LOG}"
+
+    # Parse stats; a missing/unparseable Test.xml yields a "no_result" status.
+    local stat_json
+    stat_json="$(${CI_SCRIPTS_DIR}/github_api/check_run.py stat_test_xml --test-xml="${test_xml}")"
+
+    # Merge the base event object with the parsed stats. Compact (-c) keeps it
+    # on one line; JSON flow mappings are valid YAML.
+    printf "  - " >> "${STATUS_LOG}"
+    jq -cn --arg time "${ts}" --arg event "${event}" --argjson stat "${stat_json}" \
+        '{time: $time, event: $event} + $stat'  >> "${STATUS_LOG}"
 }


### PR DESCRIPTION
This pull request adds all the code for structured logging output that will allow us to build a jedi-ci status dashboard.

Example log output

```
repo: JCSDA-internal/oops
commit: a8db6cfb897ba1d542b194dcd19cc4dbc7b0dec1
pr: "3312"
compiler: intel
scheduled: "no"
batch_job_id: 9578ff6f-5285-4a43-9776-564f6d19903f
build_identity: oops-3312-a8db6cf-intel
public_log_url: https://jedi-ci-build-public-logs.s3.us-east-2.amazonaws.com/20260603/oops-3312-a8db6cf-intel-WQGIWF56.html
start_time: 2026-06-03T20:45:20Z
events:
  - {time: 2026-06-03T20:50:53Z, event: "configure", status: "success"}
  - {time: 2026-06-03T21:22:33Z, event: "build", status: "success"}
  - {time: 2026-06-03T21:24:26Z, event: "unit_test", status: "success", passed: 329, failed: 0}
  - {time: 2026-06-03T21:24:27Z, event: "cdash_upload", status: "success", detail: "unit"}
  - {time: 2026-06-03T22:11:21Z, event: "integration_test", status: "success", passed: 2945, failed: 0}
  - {time: 2026-06-03T22:11:22Z, event: "cdash_upload", status: "success", detail: "integration"}
  - {time: 2026-06-03T22:11:25Z, event: "run", status: "complete"}
```