### PR TITLE
Add build options for ROPP, RTTOV, and OASIM

### DIFF
--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -217,6 +217,9 @@ ecbuild \
       -DCTEST_UPDATE_VERSION_ONLY=FALSE \
       -DBUILD_IODA_CONVERTERS=ON \
       -DBUILD_PYIRI=ON \
+      -DBUILD_ROPP=ON \
+      -DBUILD_RTTOV=ON \
+      -DBUILD_OASIM=ON \
       "${COMPILER_FLAGS[@]}" "${JEDI_BUNDLE_DIR}"
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Enable additional build options for the testing script. These were removed from the V2 rollout because they were part of the complex unit-test-dependency logic. They should have been moved here, and now they are.

See: https://github.com/JCSDA-internal/mpas-jedi/pull/1208