### PR TITLE
Dead code cleanup

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,10 +19,6 @@ inputs:
     description: 'Test script to run (must be in //jedi-ci/shell/)'
     required: false
     default: 'run_tests.sh'
-  target_repo_dir:
-    description: 'v2 deprecated'
-    required: false
-    default: ''
   bundle_repository:
     description: 'Repository to use when cloning the bundle.'
     required: false
@@ -33,18 +29,6 @@ inputs:
     default: 'develop'
   unittest_tag:
     description: 'CMake tag used to execute unit tests.'
-    required: false
-    default: ''
-  unittest_dependencies:
-    description: 'v2 deprecated'
-    required: false
-    default: ''
-  test_dependencies:
-    description: 'v2 deprecated'
-    required: false
-    default: ''
-  test_strategy:
-    description: 'v2 deprecated'
     required: false
     default: ''
   self_test:

--- a/cfn/jedi-ci-action.yaml
+++ b/cfn/jedi-ci-action.yaml
@@ -353,6 +353,8 @@ Resources:
         - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
         - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
         - !Ref SsmPolicyForServiceRole
+        # sccache authenticates to the build cache with the instance-role credentials (via IMDS).
+        - !Ref BatchBuildContainerIamPolicy
   IamInstanceProfile:
     Type: AWS::IAM::InstanceProfile
     Properties:

--- a/cfn/jedi-ci-action.yaml
+++ b/cfn/jedi-ci-action.yaml
@@ -235,7 +235,9 @@ Resources:
                 "arn:aws:s3:::${CachingBucketName}",
                 "arn:aws:s3:::${CachingBucketName}/*",
                 "arn:aws:s3:::${BuildInfoBucketName}",
-                "arn:aws:s3:::${BuildInfoBucketName}/*"
+                "arn:aws:s3:::${BuildInfoBucketName}/*",
+                "arn:aws:s3:::${PublicLogsBucketName}",
+                "arn:aws:s3:::${PublicLogsBucketName}/*"
               ],
               "Action": [
                 "s3:GetObject",

--- a/cfn/jedi-ci-action.yaml
+++ b/cfn/jedi-ci-action.yaml
@@ -49,10 +49,6 @@ Parameters:
     Description: The name of the S3 bucket to store public build logs.
     Type: String
     Default: jedi-ci-build-public-logs
-  CIRepoBranchName:
-    Description: The branch name for the CI repo.
-    Type: String
-    Default: develop
   TemplateBucketName:
     Type: String
     Description: The name of the bucket that contains CloudFormation templates and CI bootstrap code.
@@ -517,14 +513,10 @@ Resources:
             Value: !Ref GitHubAppID
           - Name: GITHUB_INSTALL_ID
             Value: !Ref GitHubInstallID
-          - Name: CI_REPOSITORY_BRANCH
-            Value: !Ref CIRepoBranchName
           - Name: PUBLIC_LOGS_BUCKET
             Value: !Ref PublicLogsBucketName
           - Name: JEDI_COMPILER
             Value: gcc11
-          - Name: CONTAINER_VERSION
-            Value: latest
           - Name: TRIGGER_REPO_FULL
             Value: unknown
           - Name: CONFIGURED_BUNDLE_TARBALL_S3
@@ -538,10 +530,6 @@ Resources:
           - Name: TRIGGER_SHA
             Value: ""
           - Name: TRIGGER_PR
-            Value: ""
-          - Name: INTEGRATION_RUN_ID
-            Value: ""
-          - Name: UNIT_RUN_ID
             Value: ""
         Secrets:
           - Name: GITHUB_APP_PRIVATE_KEY
@@ -574,14 +562,10 @@ Resources:
             Value: !Ref GitHubAppID
           - Name: GITHUB_INSTALL_ID
             Value: !Ref GitHubInstallID
-          - Name: CI_REPOSITORY_BRANCH
-            Value: !Ref CIRepoBranchName
           - Name: PUBLIC_LOGS_BUCKET
             Value: !Ref PublicLogsBucketName
           - Name: JEDI_COMPILER
             Value: gcc
-          - Name: CONTAINER_VERSION
-            Value: latest
           - Name: TRIGGER_REPO_FULL
             Value: unknown
           - Name: CONFIGURED_BUNDLE_TARBALL_S3
@@ -595,10 +579,6 @@ Resources:
           - Name: TRIGGER_SHA
             Value: ""
           - Name: TRIGGER_PR
-            Value: ""
-          - Name: INTEGRATION_RUN_ID
-            Value: ""
-          - Name: UNIT_RUN_ID
             Value: ""
         Secrets:
           - Name: GITHUB_APP_PRIVATE_KEY
@@ -631,14 +611,10 @@ Resources:
             Value: !Ref GitHubAppID
           - Name: GITHUB_INSTALL_ID
             Value: !Ref GitHubInstallID
-          - Name: CI_REPOSITORY_BRANCH
-            Value: !Ref CIRepoBranchName
           - Name: PUBLIC_LOGS_BUCKET
             Value: !Ref PublicLogsBucketName
           - Name: JEDI_COMPILER
             Value: intel
-          - Name: CONTAINER_VERSION
-            Value: latest
           - Name: TRIGGER_REPO_FULL
             Value: unknown
           - Name: CONFIGURED_BUNDLE_TARBALL_S3
@@ -652,10 +628,6 @@ Resources:
           - Name: TRIGGER_SHA
             Value: ""
           - Name: TRIGGER_PR
-            Value: ""
-          - Name: INTEGRATION_RUN_ID
-            Value: ""
-          - Name: UNIT_RUN_ID
             Value: ""
         Secrets:
           - Name: GITHUB_APP_PRIVATE_KEY
@@ -690,14 +662,10 @@ Resources:
             Value: !Ref GitHubAppID
           - Name: GITHUB_INSTALL_ID
             Value: !Ref GitHubInstallID
-          - Name: CI_REPOSITORY_BRANCH
-            Value: !Ref CIRepoBranchName
           - Name: PUBLIC_LOGS_BUCKET
             Value: !Ref PublicLogsBucketName
           - Name: JEDI_COMPILER
             Value: gcc11
-          - Name: CONTAINER_VERSION
-            Value: next
           - Name: TRIGGER_REPO_FULL
             Value: unknown
           - Name: CONFIGURED_BUNDLE_TARBALL_S3
@@ -711,10 +679,6 @@ Resources:
           - Name: TRIGGER_SHA
             Value: ""
           - Name: TRIGGER_PR
-            Value: ""
-          - Name: INTEGRATION_RUN_ID
-            Value: ""
-          - Name: UNIT_RUN_ID
             Value: ""
         Secrets:
           - Name: GITHUB_APP_PRIVATE_KEY
@@ -747,14 +711,10 @@ Resources:
             Value: !Ref GitHubAppID
           - Name: GITHUB_INSTALL_ID
             Value: !Ref GitHubInstallID
-          - Name: CI_REPOSITORY_BRANCH
-            Value: !Ref CIRepoBranchName
           - Name: PUBLIC_LOGS_BUCKET
             Value: !Ref PublicLogsBucketName
           - Name: JEDI_COMPILER
             Value: gcc
-          - Name: CONTAINER_VERSION
-            Value: next
           - Name: TRIGGER_REPO_FULL
             Value: unknown
           - Name: CONFIGURED_BUNDLE_TARBALL_S3
@@ -768,10 +728,6 @@ Resources:
           - Name: TRIGGER_SHA
             Value: ""
           - Name: TRIGGER_PR
-            Value: ""
-          - Name: INTEGRATION_RUN_ID
-            Value: ""
-          - Name: UNIT_RUN_ID
             Value: ""
         Secrets:
           - Name: GITHUB_APP_PRIVATE_KEY
@@ -804,14 +760,10 @@ Resources:
             Value: !Ref GitHubAppID
           - Name: GITHUB_INSTALL_ID
             Value: !Ref GitHubInstallID
-          - Name: CI_REPOSITORY_BRANCH
-            Value: !Ref CIRepoBranchName
           - Name: PUBLIC_LOGS_BUCKET
             Value: !Ref PublicLogsBucketName
           - Name: JEDI_COMPILER
             Value: intel
-          - Name: CONTAINER_VERSION
-            Value: next
           - Name: TRIGGER_REPO_FULL
             Value: unknown
           - Name: CONFIGURED_BUNDLE_TARBALL_S3
@@ -825,10 +777,6 @@ Resources:
           - Name: TRIGGER_SHA
             Value: ""
           - Name: TRIGGER_PR
-            Value: ""
-          - Name: INTEGRATION_RUN_ID
-            Value: ""
-          - Name: UNIT_RUN_ID
             Value: ""
         Secrets:
           - Name: GITHUB_APP_PRIVATE_KEY

--- a/ci_action/implementation.py
+++ b/ci_action/implementation.py
@@ -156,7 +156,6 @@ def prepare_and_launch_ci_test(
     else:
         test_annotations = pr_resolve.TestAnnotations(
             build_group_map={},  # No build group for nightly runs.
-            skip_cache='false',
             debug_mode=False,
             next_ci_suffix='',  # No suffix, use primary build environment.
             test_select='random',

--- a/ci_action/library/pr_resolve.py
+++ b/ci_action/library/pr_resolve.py
@@ -22,8 +22,6 @@ BUILD_GROUP_RE = re.compile(
 # and pull request number from the captured text.
 BUILD_GROUP_LINK = re.compile(
     r'([A-Za-z0-9._-]{3,30})/([A-Za-z0-9._-]{3,40})(?:#|/pull/)([0-9]{1,7})\s*$')
-CACHE_BEHAVIOR_RE = re.compile(
-    r'^jedi-ci-build-cache\s?=\s?(skip|rebuild)\s*$', re.MULTILINE | re.IGNORECASE)
 DRAFT_PR_RUN_RE = re.compile(
     r'^run-ci-on-draft\s?=\s?([a-zA-Z]{0,10})\s*$', re.MULTILINE | re.IGNORECASE)
 DEBUG_CI_RE = re.compile(
@@ -75,7 +73,6 @@ def read_test_annotations(
         pr_payload: Union[Mapping[str, Any], None],
         testmode: bool,
         build_group_regex=BUILD_GROUP_RE,
-        cache_regex=CACHE_BEHAVIOR_RE,
         draft_regex=DRAFT_PR_RUN_RE,
         debug_regex=DEBUG_CI_RE,
         test_select_regex=CI_TEST_SELECT_RE,
@@ -116,12 +113,6 @@ def read_test_annotations(
         # the build group PR map since it will be used for bundle rewriting.
         repo_name, org = github_client.get_repo_tuple_from_github_uri(repo_uri=repo_uri)
         build_group_pr_map[f'{org.lower()}/{repo_name.lower()}'] = int(pr_number)
-
-    # Cache behavior: "rebuild" is no longer supported.
-    cache_behavior = cache_regex.findall(pr_body)
-    if cache_behavior and cache_behavior[0].lower() == 'rebuild':
-        raise Exception('Cache rebuild (annotation "jedi-ci-build-cache=rebuild")'
-                        ' is no longer supported.')
 
     # Draft pull requests must be annotated for tests to run. If a pull request
     # is a draft pull request, the tests will be skipped unless the author

--- a/ci_action/library/pr_resolve.py
+++ b/ci_action/library/pr_resolve.py
@@ -48,11 +48,6 @@ class TestAnnotations(NamedTuple):
     # used to generate the pull request build group.
     build_group_map: Mapping[str, int]
 
-    # A string value representing a json boolean ("true" or "false"), this is
-    # passed to the build-info json file. If set to "true" the test runner will
-    # not read from the cache and will build all code.
-    skip_cache: str
-
     # If True, a 2-hour sleep will be added to the conclusion of a test.
     debug_mode: bool
 
@@ -122,14 +117,11 @@ def read_test_annotations(
         repo_name, org = github_client.get_repo_tuple_from_github_uri(repo_uri=repo_uri)
         build_group_pr_map[f'{org.lower()}/{repo_name.lower()}'] = int(pr_number)
 
-    # Cache behavior: "rebuild" is no longer supported. Only 'skip'.
-    skip_cache = 'false'
+    # Cache behavior: "rebuild" is no longer supported.
     cache_behavior = cache_regex.findall(pr_body)
     if cache_behavior and cache_behavior[0].lower() == 'rebuild':
         raise Exception('Cache rebuild (annotation "jedi-ci-build-cache=rebuild")'
                         ' is no longer supported.')
-    if cache_behavior and cache_behavior[0].lower() == 'skip':
-        skip_cache = 'true'
 
     # Draft pull requests must be annotated for tests to run. If a pull request
     # is a draft pull request, the tests will be skipped unless the author
@@ -167,7 +159,6 @@ def read_test_annotations(
 
     return TestAnnotations(
         build_group_map=build_group_pr_map,
-        skip_cache=skip_cache,
         debug_mode=debug_mode,
         next_ci_suffix=next_ci_suffix,
         test_select=test_select,

--- a/shell/environment.sh
+++ b/shell/environment.sh
@@ -34,7 +34,6 @@ fi
 if [ ! -d "${WORKDIR}" ]; then
     mkdir -p "${WORKDIR}"
 fi
-mkdir "${WORKDIR}"
 mkdir "${WORKDIR}/build"
 mkdir "${WORKDIR}/build/module"
 export BUILD_DIR="${WORKDIR}/build"

--- a/shell/github_api/check_run.py
+++ b/shell/github_api/check_run.py
@@ -133,16 +133,12 @@ ALLOWED_CONCLUSIONS = [
     "skipped",
     "timed_out",
 ]
-NotSet = github.GithubObject.NotSet
 
 
 # Arguments common to sub-commands.
 PARSER = argparse.ArgumentParser()
 
 SUBPARSERS = PARSER.add_subparsers(help='sub-command help')
-PARSER_NEW = SUBPARSERS.add_parser(
-    'new',
-    help='create a new queued check run for a commit to a repository.')
 PARSER_UPDATE = SUBPARSERS.add_parser(
     'update',
     help='Update an existing check run.')
@@ -153,7 +149,7 @@ PARSER_END = SUBPARSERS.add_parser(
 
 
 # Common arguments for parsers that interact with the API.
-for subparser in [PARSER_NEW, PARSER_UPDATE, PARSER_END]:
+for subparser in [PARSER_UPDATE, PARSER_END]:
     subparser.add_argument(
         '--app-id',
         required=True,
@@ -166,25 +162,6 @@ for subparser in [PARSER_NEW, PARSER_UPDATE, PARSER_END]:
         '--repo',
         required=True,
         help='The repository path in the form of "user/repo-name".')
-
-
-PARSER_NEW.add_argument(
-    '--commit',
-    required=True,
-    help='The full commit hash of the test target.')
-PARSER_NEW.add_argument(
-    '--test-platform',
-    required=True,
-    help='The test platform used for test output and workflow titles.')
-PARSER_NEW.add_argument(
-    '--ecs-metadata-uri',
-    default='',
-    help='URI for the AWS ECS metadata server (generally found using the '
-         'ECS_CONTAINER_METADATA_URI_V4 environment variable).')
-PARSER_NEW.add_argument(
-    '--batch-task-id',
-    default='',
-    help='The AWS Batch task ID.')
 
 
 PARSER_UPDATE.add_argument(
@@ -490,39 +467,9 @@ def get_authed_github_client(app_id, app_private_key, repo_owner, repo_name):
     return github.Github(app_auth=auth)
 
 
-def _create_check_run(app_client, repo, commit, run_name, details_url=NotSet):
-    """Create a new GitHub check run."""
-    repo_object = app_client.get_repo(repo)
-    check_run = repo_object.create_check_run(
-        run_name,
-        commit,
-        details_url=details_url,
-        status='queued',
-    )
-    return check_run
-
-
 #
 # The following functions are receivers for the argparse subparsers.
 #
-
-
-def check_run_new(args, app_id, app_key, repo_owner, repo_name):
-    """Create a new check run. Used for "new" subparser."""
-    commit = args.commit
-    client = get_authed_github_client(
-        app_id, app_key, repo_owner, repo_name)
-    test_name = f'JEDI CI test: {args.test_platform}'
-
-    metadata = ECSTaskMetaData(args.ecs_metadata_uri, args.batch_task_id)
-    run = _create_check_run(
-        app_client=client,
-        repo=f'{repo_owner}/{repo_name}',
-        commit=commit,
-        run_name=test_name,
-        details_url=metadata.batch_task_url())
-
-    print(f'{run.id}')
 
 
 def check_run_update(args, app_id, app_key, repo_owner, repo_name):
@@ -685,7 +632,6 @@ if __name__ == '__main__':
     # Setting the arg "func" value must be done at the end of this file due to
     # Python's lexical scoping of identifiers.
     PARSER.set_defaults(func=print_help)
-    PARSER_NEW.set_defaults(func=check_run_new)
     PARSER_UPDATE.set_defaults(func=check_run_update)
     PARSER_END.set_defaults(func=check_run_end)
     PARSER_EVAL.set_defaults(func=eval_test_xml)

--- a/shell/run_tests.sh
+++ b/shell/run_tests.sh
@@ -102,11 +102,6 @@ EOF
 echo "Fortran compiler version"
 $FC -v
 
-# For local testing, check runs are created by this script.
-if [ "${CREATE_CHECK_RUNS}" == "yes" ]; then
-    export CHECK_RUN_ID=$(util.check_run_new $TRIGGER_REPO_FULL $TRIGGER_SHA)
-fi
-
 echo "--------------------------------------------------------------"
 echo "Platform debug info"
 echo "--------------------------------------------------------------"
@@ -186,7 +181,6 @@ mkdir "${JEDI_BUNDLE_DIR}/cmake"
 cp "${SCRIPT_DIR}/ctest_assets/CTestConfig.cmake"       "${JEDI_BUNDLE_DIR}/"
 cp "${SCRIPT_DIR}/ctest_assets/CTestCustom.ctest.in"    "${JEDI_BUNDLE_DIR}/cmake/"
 cp "${SCRIPT_DIR}/ctest_assets/cdash-integration.cmake" "${JEDI_BUNDLE_DIR}/cmake/"
-sed -i "s#CDASH_URL#${CDASH_URL}#g"           "${JEDI_BUNDLE_DIR}/CTestConfig.cmake"
 sed -i "s#CDASH_URL#${CDASH_URL}#g"           "${JEDI_BUNDLE_DIR}/CTestConfig.cmake"
 sed -i "s#TEST_TARGET_NAME#${TRIGGER_REPO}#g" "${JEDI_BUNDLE_DIR}/CTestConfig.cmake"
 

--- a/shell/util.sh
+++ b/shell/util.sh
@@ -52,26 +52,6 @@ util.create_cdash_url() {
     echo "${CDASH_URL}/viewTest.php?buildid=$buildID"
 }
 
-# Create a new check run in the queued state.
-# Takes three arguments:
-#     $1: Repository name in "owner/repo" format.
-#     $2: trigger commit sha hash.
-util.check_run_new() {
-    if [ $SKIP_GITHUB_CHECK_RUNS = 'yes' ]; then
-        return 0
-    fi
-    repo=$1
-    commit_sha=$2
-    ${CI_SCRIPTS_DIR}/github_api/check_run.py new \
-        --app-private-key="${GITHUB_APP_PRIVATE_KEY_FILE}" \
-        --app-id="${GITHUB_APP_ID}" \
-        --repo=$repo \
-        --commit=$commit_sha \
-        --test-platform=${JEDI_COMPILER} \
-        --ecs-metadata-uri="${ECS_CONTAINER_METADATA_URI_V4}" \
-        --batch-task-id="${AWS_BATCH_JOB_ID}"
-}
-
 # Update a check run setting the status to failure and giving a simple
 # reason for the failure like "compile failed" or similar. Args:
 #     $1: Repository name in "owner/repo" format.


### PR DESCRIPTION
This pull request removes dead code from jedi-ci.

* `action.yml`: delete  all deprecated arguments (repo_dir, \*_dependencies,  and strategy)
* `jedi-ci-build-cache` annotation removed (no longer used)
* `CloudFormation`: severak dead env vars removed from all job definitions
* Test runner:
  * `run_tests.sh`: CREATE_CHECK_RUNS removed from the runner script (this was an old test fixture that is never used).
  * `check_run.py`: Remove code used by CREATE_CHECK_RUNS.
* Other small deletions.

