### PR TITLE
Small logging improvements

### DIFF
--- a/shell/bootstrap_test.sh
+++ b/shell/bootstrap_test.sh
@@ -38,8 +38,7 @@ handle_preemption() {
     PREEMPTION_HANDLED=1
     echo "Runner preemption signal received; flushing logs before exit."
     kill "$MONITOR_PID" 2>/dev/null || true
-    [ -f "$STATUS_LOG" ] && util.status_log_event "run_canceled" "success" \
-        "Test was canceled or preempted externally"
+    [ -f "$STATUS_LOG" ] && util.status_log_event "run" "preempted" "Test was canceled or preempted externally"
     upload_logs
     exit 143  # 128 + SIGTERM
 }

--- a/shell/bootstrap_test.sh
+++ b/shell/bootstrap_test.sh
@@ -20,6 +20,30 @@ export STATUS_LOG="/tmp/status.log"
 export STATUS_LOG_S3="s3://${PUBLIC_LOGS_BUCKET}/${_DATE}/${BUILD_IDENTITY}-${_RANDOM}.status.yaml"
 export STATUS_LOG_URL="https://${PUBLIC_LOGS_BUCKET}.s3.${_REGION}.amazonaws.com/${_DATE}/${BUILD_IDENTITY}-${_RANDOM}.status.yaml"
 
+# Sourced for util.status_log_event, used by the preemption handler.
+source "$SCRIPT_DIR/util.sh"
+
+# Convert build logs to HTML and push logs + status log to the public bucket.
+upload_logs() {
+    cat /tmp/build_logs.txt | python -m ansi2html -l > /tmp/build_logs.html
+    aws s3 cp /tmp/build_logs.html $PUBLIC_LOG_S3 --content-type "text/html"
+    [ -f "$STATUS_LOG" ] && aws s3 cp "$STATUS_LOG" "$STATUS_LOG_S3" --content-type "text/plain"
+}
+
+# AWS Batch/Spot sends SIGTERM before reclaiming the instance. Flush logs to S3
+# before the SIGKILL grace period expires rather than losing the upload window.
+PREEMPTION_HANDLED=0
+handle_preemption() {
+    [ "$PREEMPTION_HANDLED" -eq 1 ] && return  # re-entrancy guard
+    PREEMPTION_HANDLED=1
+    echo "Runner preemption signal received; flushing logs before exit."
+    kill "$MONITOR_PID" 2>/dev/null || true
+    [ -f "$STATUS_LOG" ] && util.status_log_event "run_canceled" "success" \
+        "Test was canceled or preempted externally"
+    upload_logs
+    exit 143  # 128 + SIGTERM
+}
+
 # Setup GitHub app credentials.
 cp $SCRIPT_DIR/git_askPass_app_credentials.py /bin/git_askPass_app_credentials.py
 chmod +x /bin/git_askPass_app_credentials.py
@@ -59,9 +83,7 @@ sleep 30
 MONITOR_UPLOADS=0
 SLEEP_TIME=120  # 2 minutes
 while kill -0 $TEST_PID 2>/dev/null; do
-    cat /tmp/build_logs.txt | python -m ansi2html -l > /tmp/build_logs.html
-    aws s3 cp /tmp/build_logs.html $PUBLIC_LOG_S3 --content-type "text/html"
-    [ -f "$STATUS_LOG" ] && aws s3 cp "$STATUS_LOG" "$STATUS_LOG_S3" --content-type "text/plain"
+    upload_logs
     sleep $SLEEP_TIME
     MONITOR_UPLOADS=$((MONITOR_UPLOADS + 1))
     if [[ $MONITOR_UPLOADS == 5 ]]; then
@@ -69,6 +91,9 @@ while kill -0 $TEST_PID 2>/dev/null; do
     fi
 done &
 MONITOR_PID=$!
+
+# Catch preemption (Batch/Spot SIGTERM) during the long test window.
+trap handle_preemption SIGTERM SIGINT
 
 wait $TEST_PID
 TEST_EXIT_CODE=$?
@@ -79,7 +104,5 @@ kill $MONITOR_PID 2>/dev/null || true
 sleep 1
 
 set -x
-cat /tmp/build_logs.txt | python -m ansi2html -l > /tmp/build_logs.html
-aws s3 cp /tmp/build_logs.html $PUBLIC_LOG_S3 --content-type "text/html"
-[ -f "$STATUS_LOG" ] && aws s3 cp "$STATUS_LOG" "$STATUS_LOG_S3" --content-type "text/plain"
+upload_logs
 df -h

--- a/shell/util.sh
+++ b/shell/util.sh
@@ -311,7 +311,7 @@ EOF
 # Append a single lifecycle event to the status log.
 # Args:
 #     $1: event name (e.g. "configure", "build", "unit_test", "cdash_upload").
-#     $2: status (e.g. "start", "success", "failure", "skipped").
+#     $2: status (e.g. "success", "failure", "skipped").
 #     $3: (optional) free-form human-readable detail string, defaults to "".
 util.status_log_event() {
     local event="$1"

--- a/shell/util.sh
+++ b/shell/util.sh
@@ -265,15 +265,20 @@ util.ctest_LE_flag() {
 # to the public bucket for aggregation into a global status dashboard. Unlike
 # CDash, this captures failures before or during configure/build.
 #
+# Note the status_log_schema field exists to allow incompatible edits to the
+# schema of this log. Generally it should only be updated if deleting fields.
+#
 # Example output:
 #
 #   repo: JCSDA/ufo
 #   commit: a1b2c3d
+#   status_log_schema: 1
 #   pr: "42"
 #   compiler: gcc11
 #   batch_job_id: abc-123
 #   build_identity: ufo-gcc11
 #   public_log_url: https://.../ufo-gcc11-xxxx.html
+#   check_run_id: 81633945680
 #   start_time: 2026-06-03T12:00:00Z
 #   events:
 #     - {time: 2026-06-03T12:01:00Z, event: configure, status: success}
@@ -290,12 +295,14 @@ util.status_log_init() {
     cat > "${STATUS_LOG}" <<EOF
 repo: ${TRIGGER_REPO_FULL}
 commit: ${TRIGGER_SHA}
+status_log_schema: 1
 pr: "${TRIGGER_PR}"
 compiler: ${JEDI_COMPILER}
 scheduled: "${IS_SCHEDULED:-no}"
 batch_job_id: ${AWS_BATCH_JOB_ID}
 build_identity: ${BUILD_IDENTITY}
 public_log_url: ${PUBLIC_LOG_URL}
+check_run_id: ${CHECK_RUN_ID:-0}
 start_time: ${ts}
 events:
 EOF


### PR DESCRIPTION
In my first draft of the ci-status dashboard I found a few problems that this PR resolves.

1) Canceled jobs are ambiguous from hangs/timeouts. __Fix__: add a trap that logs the cancellation.

2) I cannot link to the check-run status page. __Fix__: log the `check_run_id`